### PR TITLE
Add support for reading more types

### DIFF
--- a/modules/core/js/src/main/scala/ciris/readers/ConfigReaders.scala
+++ b/modules/core/js/src/main/scala/ciris/readers/ConfigReaders.scala
@@ -3,6 +3,7 @@ package ciris.readers
 trait ConfigReaders
     extends DerivedConfigReaders
     with DurationConfigReaders
+    with JavaNioCharsetConfigReaders
     with JavaUtilConfigReaders
     with MathConfigReaders
     with PrimitiveConfigReaders

--- a/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
@@ -4,6 +4,8 @@ trait ConfigReaders
     extends DerivedConfigReaders
     with DurationConfigReaders
     with JavaNetConfigReaders
+    with JavaNioCharsetConfigReaders
+    with JavaNioFileConfigReaders
     with JavaTimeConfigReaders
     with JavaUtilConfigReaders
     with MathConfigReaders

--- a/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
@@ -3,6 +3,7 @@ package ciris.readers
 trait ConfigReaders
     extends DerivedConfigReaders
     with DurationConfigReaders
+    with JavaIoConfigReaders
     with JavaNetConfigReaders
     with JavaNioCharsetConfigReaders
     with JavaNioFileConfigReaders

--- a/modules/core/jvm/src/main/scala/ciris/readers/JavaIoConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/JavaIoConfigReaders.scala
@@ -1,0 +1,10 @@
+package ciris.readers
+
+import java.io.File
+
+import ciris.ConfigReader
+
+trait JavaIoConfigReaders {
+  implicit val fileConfigReader: ConfigReader[File] =
+    ConfigReader.catchNonFatal("File")(new File(_))
+}

--- a/modules/core/jvm/src/main/scala/ciris/readers/JavaNetConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/JavaNetConfigReaders.scala
@@ -1,11 +1,14 @@
 package ciris.readers
 
-import java.net.{URI, URL}
+import java.net._
 
 import ciris.ConfigReader
 import ciris.ConfigReader.catchNonFatal
 
 trait JavaNetConfigReaders {
+  implicit val inetAddressConfigReader: ConfigReader[InetAddress] =
+    catchNonFatal("InetAddress")(InetAddress.getByName)
+
   implicit val uriConfigReader: ConfigReader[URI] =
     catchNonFatal("URI")(new URI(_))
 

--- a/modules/core/jvm/src/main/scala/ciris/readers/JavaNioFileConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/JavaNioFileConfigReaders.scala
@@ -1,0 +1,10 @@
+package ciris.readers
+
+import java.nio.file._
+
+import ciris.ConfigReader
+
+trait JavaNioFileConfigReaders {
+  implicit val pathConfigReader: ConfigReader[Path] =
+    ConfigReader.catchNonFatal("Path")(Paths.get(_))
+}

--- a/modules/core/jvm/src/test/scala/ciris/readers/JavaIoConfigReadersSpec.scala
+++ b/modules/core/jvm/src/test/scala/ciris/readers/JavaIoConfigReadersSpec.scala
@@ -1,0 +1,17 @@
+package ciris.readers
+
+import java.io.File
+
+import ciris.PropertySpec
+
+final class JavaIoConfigReadersSpec extends PropertySpec {
+  "JavaIoConfigReaders" when {
+    "reading a File" should {
+      "successfully read File values" in {
+        forAll { string: String ⇒
+          readValue[File](string) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/modules/core/jvm/src/test/scala/ciris/readers/JavaNetConfigReadersSpec.scala
+++ b/modules/core/jvm/src/test/scala/ciris/readers/JavaNetConfigReadersSpec.scala
@@ -1,12 +1,21 @@
 package ciris.readers
 
-import java.net.{URI, URL}
+import java.net.{InetAddress, URI, URL}
 
 import ciris.PropertySpec
 import org.scalacheck.Gen
 
 final class JavaNetConfigReadersSpec extends PropertySpec {
   "JavaNetConfigReaders" when {
+    "reading an InetAddress" should {
+      "successfully read InetAddress values" in {
+        val exampleAddresses = Gen.oneOf("localhost", "127.0.0.1")
+        forAll(exampleAddresses) { exampleAddress ⇒
+          readValue[InetAddress](exampleAddress) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
     "reading an URI" should {
       "successfully read URI values" in {
         val exampleUris = Gen.oneOf("http://localhost", "ftp://localhost")

--- a/modules/core/jvm/src/test/scala/ciris/readers/JavaNioCharsetConfigReadersJvmSpec.scala
+++ b/modules/core/jvm/src/test/scala/ciris/readers/JavaNioCharsetConfigReadersJvmSpec.scala
@@ -1,0 +1,23 @@
+package ciris.readers
+
+import java.nio.charset.Charset
+
+import ciris.PropertySpec
+import org.scalacheck.Gen
+
+import scala.collection.JavaConverters._
+
+final class JavaNioCharsetConfigReadersJvmSpec extends PropertySpec {
+  "JavaNioCharsetConfigReaders" when {
+    "reading a Charset" should {
+      "successfully read available charsets" in {
+        val availableCharsets = Charset.availableCharsets().keySet().asScala.toSeq
+        val genAvailableCharset = Gen.oneOf(availableCharsets).flatMap(mixedCase)
+
+        forAll(genAvailableCharset) { charset ⇒
+          readValue[Charset](charset) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/modules/core/jvm/src/test/scala/ciris/readers/JavaNioFileConfigReadersSpec.scala
+++ b/modules/core/jvm/src/test/scala/ciris/readers/JavaNioFileConfigReadersSpec.scala
@@ -1,0 +1,27 @@
+package ciris.readers
+
+import java.nio.file.{Path, Paths}
+
+import ciris.PropertySpec
+import org.scalacheck.Gen
+
+final class JavaNioFileConfigReadersSpec extends PropertySpec {
+  "JavaNioFileConfigReaders" when {
+    "reading a Path" should {
+      "successfully read Path values" in {
+        forAll { string: String ⇒
+          whenever(!fails(Paths.get(string))) {
+            readValue[Path](string) shouldBe Right(Paths.get(string))
+          }
+        }
+      }
+
+      "return a failure for invalid values" in {
+        val invalidPaths = List[String](null, "\u0000")
+        forAll(Gen.oneOf(invalidPaths)) { invalidPath ⇒
+          readValue[Path](invalidPath) shouldBe a[Left[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/modules/core/shared/src/main/scala/ciris/readers/JavaNioCharsetConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/JavaNioCharsetConfigReaders.scala
@@ -1,0 +1,10 @@
+package ciris.readers
+
+import java.nio.charset._
+
+import ciris.ConfigReader
+
+trait JavaNioCharsetConfigReaders {
+  implicit val charsetConfigReader: ConfigReader[Charset] =
+    ConfigReader.catchNonFatal("Charset")(Charset.forName)
+}

--- a/modules/core/shared/src/main/scala/ciris/readers/JavaUtilConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/JavaUtilConfigReaders.scala
@@ -1,11 +1,15 @@
 package ciris.readers
 
 import java.util.UUID
+import java.util.regex.Pattern
 
 import ciris.ConfigReader
 import ciris.ConfigReader.catchNonFatal
 
 trait JavaUtilConfigReaders {
+  implicit val regexPatternConfigReader: ConfigReader[Pattern] =
+    catchNonFatal("Pattern")(Pattern.compile)
+
   implicit val uuidConfigReader: ConfigReader[UUID] =
     catchNonFatal("UUID")(UUID.fromString)
 }

--- a/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
@@ -17,13 +17,13 @@ trait PrimitiveConfigReaders {
 
   implicit val doubleConfigReader: ConfigReader[Double] =
     catchNonFatal("Double") {
-      case s if s.lastOption.exists(_ == '%') ⇒ s.dropRight(1).toDouble / 100d
+      case s if s.lastOption.exists(_ == '%') ⇒ s.init.toDouble / 100d
       case s ⇒ s.toDouble
     }
 
   implicit val floatConfigReader: ConfigReader[Float] =
     catchNonFatal("Float") {
-      case s if s.lastOption.exists(_ == '%') ⇒ s.dropRight(1).toFloat / 100f
+      case s if s.lastOption.exists(_ == '%') ⇒ s.init.toFloat / 100f
       case s ⇒ s.toFloat
     }
 

--- a/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
@@ -16,10 +16,16 @@ trait PrimitiveConfigReaders {
     }
 
   implicit val doubleConfigReader: ConfigReader[Double] =
-    catchNonFatal("Double")(_.toDouble)
+    catchNonFatal("Double") {
+      case s if s.lastOption.exists(_ == '%') ⇒ s.dropRight(1).toDouble / 100d
+      case s ⇒ s.toDouble
+    }
 
   implicit val floatConfigReader: ConfigReader[Float] =
-    catchNonFatal("Float")(_.toFloat)
+    catchNonFatal("Float") {
+      case s if s.lastOption.exists(_ == '%') ⇒ s.dropRight(1).toFloat / 100f
+      case s ⇒ s.toFloat
+    }
 
   implicit val intConfigReader: ConfigReader[Int] =
     catchNonFatal("Int")(_.toInt)

--- a/modules/core/shared/src/test/scala/ciris/readers/JavaNioCharsetConfigReadersSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/readers/JavaNioCharsetConfigReadersSpec.scala
@@ -1,0 +1,19 @@
+package ciris.readers
+
+import java.nio.charset.Charset
+
+import ciris.PropertySpec
+
+final class JavaNioCharsetConfigReadersSpec extends PropertySpec {
+  "JavaNioCharsetConfigReaders" when {
+    "reading a Charset" should {
+      "return a failure for unrecognized values" in {
+        forAll { string: String ⇒
+          whenever(fails(Charset.forName(string))) {
+            readValue[Charset](string) shouldBe a[Left[_, _]]
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/core/shared/src/test/scala/ciris/readers/JavaUtilConfigReadersSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/readers/JavaUtilConfigReadersSpec.scala
@@ -1,12 +1,29 @@
 package ciris.readers
 
 import java.util.UUID
+import java.util.regex.Pattern
 
 import ciris.PropertySpec
 import org.scalacheck.Gen
 
 final class JavaUtilConfigReadersSpec extends PropertySpec {
   "JavaUtilConfigReaders" when {
+    "reading a regex Pattern" should {
+      "successfully read Pattern values" in {
+        val examplePatterns = List("[a-z&&[def]]", "(\\D)")
+        forAll(Gen.oneOf(examplePatterns)) { examplePattern ⇒
+          readValue[Pattern](examplePattern) shouldBe a[Right[_, _]]
+        }
+      }
+
+      "return a failure for other values" in {
+        val exampleInvalidPatterns = List("[AB", "(CD[E]")
+        forAll(Gen.oneOf(exampleInvalidPatterns)) { exampleInvalidPattern ⇒
+          readValue[Pattern](exampleInvalidPattern) shouldBe a[Left[_, _]]
+        }
+      }
+    }
+
     "reading an UUID" should {
       "successfully read UUID values" in {
         forAll(Gen.uuid) { uuid ⇒

--- a/modules/core/shared/src/test/scala/ciris/readers/PrimitiveConfigReadersSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/readers/PrimitiveConfigReadersSpec.scala
@@ -65,6 +65,12 @@ final class PrimitiveConfigReadersSpec extends PropertySpec {
         }
       }
 
+      "successfully read Double percentage values" in {
+        forAll { double: Double ⇒
+          readValue[Double](double.toString + "%") shouldBe Right(double / 100d)
+        }
+      }
+
       "return a failure for other values" in {
         forAll { string: String ⇒
           whenever(fails(string.toDouble)) {
@@ -78,6 +84,12 @@ final class PrimitiveConfigReadersSpec extends PropertySpec {
       "successfully read Float values" in {
         forAll { float: Float ⇒
           readValue[Float](float.toString) shouldBe Right(float)
+        }
+      }
+
+      "successfully read Float percentage values" in {
+        forAll { float: Float ⇒
+          readValue[Float](float.toString + "%") shouldBe Right(float / 100f)
         }
       }
 


### PR DESCRIPTION
Add support for reading:
- `Double` and `Float` percent format (i.e. `57%` becomes `0.57`)
- `java.io.File`
- `java.net.InetAddress`
- `java.nio.charset.Charset`
- `java.nio.file.Path`
- `java.util.regex.Pattern`