### PR TITLE
Upgrade squants to 1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val refinedJVM = refined.jvm
 lazy val squants = crossProject
   .in(file("modules/squants"))
   .settings(moduleName := "ciris-squants", name := "Ciris squants")
-  .settings(libraryDependencies += "org.typelevel" %%% "squants" % "1.2.0")
+  .settings(libraryDependencies += "org.typelevel" %%% "squants" % "1.3.0")
   .settings(scalaSettings)
   .settings(releaseSettings)
   .dependsOn(core)

--- a/modules/squants/shared/src/main/scala/ciris/squants/readers/SquantsConfigReaders.scala
+++ b/modules/squants/shared/src/main/scala/ciris/squants/readers/SquantsConfigReaders.scala
@@ -83,10 +83,16 @@ trait SquantsConfigReaders {
   implicit val massConfigReader: ConfigReader[Mass] =
     fromTry("Mass")(Mass.apply)
 
+  implicit val momentOfInertiaConfigReader: ConfigReader[MomentOfInertia] =
+    fromTry("MomentOfInertia")(MomentOfInertia.apply)
+
   import squants.motion._
 
   implicit val accelerationConfigReader: ConfigReader[Acceleration] =
     fromTry("Acceleration")(Acceleration.apply)
+
+  implicit val angularAccelerationConfigReader: ConfigReader[AngularAcceleration] =
+    fromTry("AngularAcceleration")(AngularAcceleration.apply)
 
   implicit val angularVelocityConfigReader: ConfigReader[AngularVelocity] =
     fromTry("AngularVelocity")(AngularVelocity.apply)
@@ -108,6 +114,9 @@ trait SquantsConfigReaders {
 
   implicit val pressureChangeConfigReader: ConfigReader[PressureChange] =
     fromTry("PressureChange")(PressureChange.apply)
+
+  implicit val torqueConfigReader: ConfigReader[Torque] =
+    fromTry("Torque")(Torque.apply)
 
   implicit val velocityConfigReader: ConfigReader[Velocity] =
     fromTry("Velocity")(Velocity.apply)

--- a/tests/shared/src/test/scala/ciris/squants/readers/SquantsConfigReadersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/squants/readers/SquantsConfigReadersSpec.scala
@@ -47,10 +47,12 @@ final class SquantsConfigReadersSpec extends PropertySpec with SquantsGenerators
     testDimension(ChemicalAmount, ChemicalAmount.apply)
     testDimension(Density, Density.apply)
     testDimension(Mass, Mass.apply)
+    testDimension(MomentOfInertia, MomentOfInertia.apply)
 
     import squants.motion._
 
     testDimension(Acceleration, Acceleration.apply)
+    testDimension(AngularAcceleration, AngularAcceleration.apply)
     testDimension(AngularVelocity, AngularVelocity.apply)
     testDimension(Force, Force.apply)
     testDimension(Jerk, Jerk.apply)
@@ -58,6 +60,7 @@ final class SquantsConfigReadersSpec extends PropertySpec with SquantsGenerators
     testDimension(Momentum, Momentum.apply)
     testDimension(Pressure, Pressure.apply)
     testDimension(PressureChange, PressureChange.apply)
+    testDimension(Torque, Torque.apply)
     testDimension(Velocity, Velocity.apply)
     testDimension(VolumeFlow, VolumeFlow.apply)
     testDimension(Yank, Yank.apply)


### PR DESCRIPTION
Add support for reading `MomentOfInertia`, `AngularAcceleration`, and `Torque`. ([#227](https://github.com/typelevel/squants/pull/227))