### PR TITLE
Make ConfigSource not sealed

### DIFF
--- a/docs/src/main/tut/docs/sources/readme.md
+++ b/docs/src/main/tut/docs/sources/readme.md
@@ -6,7 +6,7 @@ permalink: /docs/sources
 ---
 
 # Configuration Sources
-Ciris provides support for reading environment variables and system properties. If you require other  configurations sources, you can easily define your own. You'll find helper methods for creating custom configuration sources in the companion object of [`ConfigSource`](https://cir.is/api/ciris/ConfigSource$.html). Let's illustrate this by writing a configuration source which captures the current system properties at a certain point in time, ignoring any later changes.
+Ciris provides support for reading environment variables and system properties. If you're looking for a common configuration source not yet supported, please [file an issue](https://github.com/vlovgr/ciris/issues/new) or, even better, submit a pull-request. If you require other configurations sources, you can easily define your own. You'll find helper methods for creating custom configuration sources in the companion object of [`ConfigSource`](https://cir.is/api/ciris/ConfigSource$.html). Let's illustrate this by writing a configuration source which captures the current system properties at a certain point in time, ignoring any later changes.
 
 To create a configuration source, we need to provide a `ConfigKeyType` which is the name of the type of key the source reads (to support sensible error messages). We can convert the current system properties to a `Map` and create a `ConfigSource` from it using the `fromMap` method. If we make the source implicit and have it in scope, the `read` method will read `ConfigValue` configuration values from it. We can convert a `ConfigValue[T]` to an `Either[ConfigError, T]` by calling the `value` method.
 

--- a/docs/src/main/tut/docs/validation/readme.md
+++ b/docs/src/main/tut/docs/validation/readme.md
@@ -26,7 +26,7 @@ final case class Config(
 )
 ```
 
-Here we've said that the API key must be a non-empty `String` and that the port number must be an integer between 0 and 65535. We could also require that the timeout must be finite and within a certain range, but since it's always specified in the code, it's arguably harder to get wrong. Now, let's see how we can simply change the types to read in the `env` and `prop` methods to the refined types, and how Ciris will take of loading them for you.
+Here we've said that the API key must be a non-empty `String` and that the port number must be an integer between 0 and 65535. We could also require that the timeout must be finite and within a certain range, but since it's always specified in the code, it's arguably harder to get wrong. Now, let's see how we can simply change the types to read in the `env` and `prop` methods to the refined types, and how Ciris will take care of loading them for you.
 
 ```tut:book
 import ciris._

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -4,7 +4,7 @@ import ciris.ConfigError.{MissingKey, ReadException}
 
 import scala.util.{Failure, Success, Try}
 
-sealed abstract class ConfigSource(val keyType: ConfigKeyType) {
+abstract class ConfigSource(val keyType: ConfigKeyType) {
   def read(key: String): Either[ConfigError, String]
 }
 


### PR DESCRIPTION
To support use cases related to custom configuration sources.