### PR TITLE
Add Core Concepts and Modules Overview sections to usage guide

### DIFF
--- a/docs/src/main/resources/microsite/css/custom.css
+++ b/docs/src/main/resources/microsite/css/custom.css
@@ -1,5 +1,7 @@
 a:hover, a:focus {
   color: #3e4959;
+  text-decoration-skip: ink;
+  -webkit-text-decoration-skip: ink;
 }
 
 blockquote {
@@ -61,4 +63,10 @@ blockquote {
 
 .modal-kazari {
   display: none;
+}
+
+#page-content-wrapper section a:hover, #page-content-wrapper section a:focus {
+  text-decoration: underline;
+  text-decoration-skip: ink;
+  -webkit-text-decoration-skip: ink;
 }

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -1,6 +1,10 @@
 options:
   - title: Usage Basics
     url: docs/basics
+  - title: Core Concepts
+    url: docs/concepts
+  - title: Modules Overview
+    url: docs/modules
   - title: Encoding Validation
     url: docs/validation
   - title: Multiple Environments

--- a/docs/src/main/tut/docs/basics/readme.md
+++ b/docs/src/main/tut/docs/basics/readme.md
@@ -5,7 +5,7 @@ position: 1
 permalink: /docs/basics
 ---
 
-# Usage Basics
+# <a name="usage-basics" href="#usage-basics">Usage Basics</a>
 Ciris configuration loading is done in two parts: define what to load and what to create once everything is loaded. Let's start simple by defining a configuration and loading only the necessary parts of it from the environment. If you haven't already, now is also a good time to separate your application from your configuration, so that the configuration can be loaded separately.
 
 The configuration can be modeled with nested case classes. Here we'll define a small example configuration for an HTTP service, binding at a certain port, using an API key for request authorization, and using a maximum timeout when making HTTP requests to other services.
@@ -20,7 +20,7 @@ final case class Config(
 )
 ```
 
-In this case, the API key is a secret and we would like to load it from the environment. The same goes for the port, which needs to be dynamic depending on the environment. We can read environment variables using the `env` method and system properties using the `prop` method, both returning a `ConfigValue`. The `loadConfig` method then accepts `ConfigValue`s and expects a function creating the configuration using the loaded values. If there are errors while reading values, Ciris will deal with them and accumulate them for you as `ConfigErrors`.
+In this case, the API key is a secret and we would like to load it from the environment. The same goes for the port, which needs to be dynamic depending on the environment. We can read environment variables using the `env` method and system properties using the `prop` method, both returning a `ConfigValue`. The `loadConfig` method then accepts `ConfigValue`s and expects a function creating the configuration using the loaded values. If there are errors while reading values, Ciris will deal with them and accumulate them as `ConfigErrors`. You can read more about `ConfigValue` and `ConfigErrors` in [Core Concepts](/docs/concepts).
 
 ```tut:book
 import ciris._

--- a/docs/src/main/tut/docs/concepts/readme.md
+++ b/docs/src/main/tut/docs/concepts/readme.md
@@ -1,0 +1,37 @@
+---
+layout: docs
+title: "Core Concepts"
+position: 2
+permalink: /docs/concepts
+---
+
+# <a name="core-concepts" href="#core-concepts">Core Concepts</a>
+This section explains the core concepts in Ciris, including the types `ConfigSource`, `ConfigKeyType`, `ConfigReader`, `ConfigError`, `ConfigErrors`, and `ConfigValue` and the methods `loadConfig`, `withValue`, `withValues`, `env`, `prop`, and `read`. For [basic usage](/docs/basics), you do not need to have a complete understanding of these concepts, although it might be helpful. If you need to do some integration with Ciris, like creating a new [module](/docs/modules), defining a new [configuration source](/docs/sources), or writing a [custom reader](/docs/readers) to support new types, understanding these core concepts will be beneficial.
+
+## <a name="configuration-sources" href="#configuration-sources">Configuration Sources</a>
+Configuration values can be read from different sources, represented by `ConfigSource`s, which are anything that can map `String` keys to `String` values, like `Map[String, String]` for example, and that return a `ConfigError` error if there was an error while reading the value (for example, when no value exists for a given key). A `ConfigSource` reads keys of type `ConfigKeyType`, which is simply a wrapper around the key name, for example `environment variable`. The abstract class `ConfigSource` is defined as follows.
+
+```scala
+abstract class ConfigSource(val keyType: ConfigKeyType) {
+  def read(key: String): Either[ConfigError, String]
+}
+```
+
+Ciris provides `ConfigSource`s for environment variables and system properties in the core library. If you require other configuration sources, you can easily create your own. You can read more about `ConfigSource`s in the [Configuration Sources](/docs/sources) section.
+
+## <a name="configuration-readers" href="#configuration-readers">Configuration Readers</a>
+Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigReader[A]`. `ConfigReader`s accept an implicit `ConfigSource`, reads values for specified keys, and tries to convert the `String` values into type `A`, returning a `ConfigError` error if the conversion was unsuccessful or if the source could not provide a value for the key. The sealed abstract class `ConfigReader` is defined as follows.
+
+```scala
+sealed abstract class ConfigReader[A] {
+  def read(key: String)(implicit source: ConfigSource): Either[ConfigError, A]
+}
+```
+
+Ciris provides `ConfigReader` instances for many types in the standard library, and for third-party library types in separate modules. Modules like `ciris-generic` use [shapeless](https://github.com/milessabin/shapeless) to derive `ConfigReader` instances for certain types, like case classes with one argument and [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html). For more information on Ciris modules, see [Modules Overview](/docs/modules). You can also easily create your own `ConfigReader`s, as described in the [Custom Readers](/docs/readers) section.
+
+## <a name="configuration-values" href="#configuration-values">Configuration Values</a>
+A configuration value read for a specific key, from a `ConfigSource`, and converted to type `A` using a `ConfigReader[A]`, results in a `ConfigValue[A]`, which is a thin wrapper around an `Either[ConfigError, A]` instance. Ciris provides methods like `env`, `prop`, and `read` for reading `ConfigValue`s from environment variables, system properties, and other configuration sources. `ConfigValue`s are used internally to deal with error accumulation, and when loading configurations you'll typically see `ConfigErrors`, which is the result of error accumulation using `ConfigValue`s.
+
+## <a name="loading-configurations" href="#loading-configurations">Loading Configurations</a>
+The `loadConfig` and `withValues` (and `withValue`) methods allow you to combine multiple `ConfigValue`s, while accumulating errors, and using those values to create your configuration. The difference between them is that `withValues` declares a dependency required to be able to use `loadConfig` (think `flatMap`), while `loadConfig` loads your configuration using `ConfigValue`s. The `withValues` method is useful, for example, when dealing with [Multiple Environments](/docs/environments).

--- a/docs/src/main/tut/docs/environments/readme.md
+++ b/docs/src/main/tut/docs/environments/readme.md
@@ -1,11 +1,11 @@
 ---
 layout: docs
 title: "Multiple Environments"
-position: 3
+position: 5
 permalink: /docs/environments
 ---
 
-# Multiple Environments
+# <a name="multiple-environments" href="#multiple-environments">Multiple Environments</a>
 One of the most common use cases for configurations is having different values for different environments. There are several ways to deal with environments using Ciris: one way being to define an enumeration with [enumeratum][enumeratum] and use the `ciris-enumeratum` module to be able to load values of that enumeration. You can then switch configuration by just writing conditional statements in plain code.
 
 Let's start off by defining an enumeration for our environments: local, testing, and production.

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -1,0 +1,204 @@
+---
+layout: docs
+title: "Modules Overview"
+position: 3
+permalink: /docs/modules
+---
+
+# <a name="modules-overview" href="#modules-overview">Modules Overview</a>
+Ciris core module, `ciris-core`, provides basic functionality and readers for many standard library types. See [Core Concepts](/docs/concepts) for an explanation of the concepts in the core module. Remaining sections mostly cover the core module in greater detail, in particular [Configuration Sources](/docs/sources) and [Custom Readers](/docs/readers). In the sections below, Ciris' other modules are explained briefly.
+
+## <a name="enumeratum" href="#enumeratum">Enumeratum</a>
+The `ciris-enumeratum` module provides support for reading [enumeratum][enumeratum] enumerations. You can refer to the [documentation](/api/ciris/enumeratum) for a complete list of supported enumerations. As an example, let's define an `Enum` and see how we can load values of that enumeration using Ciris. Enumeratum provides mixins, like `Lowercase` below, which we can use to customize the name of our enumerations, and in turn, what values we will be able to load with Ciris.
+
+```tut:book:reset
+import enumeratum._
+import enumeratum.EnumEntry._
+
+object configuration {
+  sealed abstract class AppEnvironment extends EnumEntry with Lowercase
+  object AppEnvironment extends Enum[AppEnvironment] {
+    case object Local extends AppEnvironment
+    case object Testing extends AppEnvironment
+    case object Production extends AppEnvironment
+
+    val values = findValues
+  }
+}
+```
+
+Let's also define a custom implicit [configuration source](/docs/sources), holding some values we can ask Ciris to load.
+
+```tut:book
+import ciris._
+import ciris.enumeratum._
+import configuration._
+
+implicit val source = {
+  val keyType = ConfigKeyType("enumeratum key")
+  ConfigSource.fromMap(keyType)(Map(
+    "localEnv" -> "local",
+    "testingEnv" -> "testing",
+    "TestingEnv" -> "Testing",
+    "invalidEnv" -> "invalid"
+  ))
+}
+```
+
+We can then ask Ciris to load values of the enumeration, from the implicit source, using the `read` method.
+
+```tut:book
+read[AppEnvironment]("localEnv")
+
+read[AppEnvironment]("testingEnv")
+
+read[AppEnvironment]("TestingEnv")
+
+read[AppEnvironment]("invalidEnv")
+```
+
+Dealing with multiple environments is a common use case for configurations, explained in greater detail in the [Multiple Environments](/docs/environments) section.
+
+## <a name="generic" href="#generic">Generic</a>
+The `ciris-generic` module provides the ability to read unary products, and coproducts using [shapeless][shapeless]. This allows you to load case classes with one argument, including [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless' `Generic` supports. Let's take a brief look at these cases to see how it works in practice. We start by defining a source from which we can read configuration values.
+
+```tut:book:reset
+import ciris._
+import ciris.generic._
+
+implicit val source = {
+  val keyType = ConfigKeyType("generic key")
+  ConfigSource.fromMap(keyType)(Map("key" -> "5.0"))
+}
+```
+
+We can then define and load a unary product, for example a case class with one value.
+
+```tut:book
+final case class DoubleValue(value: Double)
+
+read[DoubleValue]("key")
+```
+
+It also works for value classes and any other unary products shapeless' `Generic` supports.
+
+```tut:book
+final class FloatValue(val value: Float) extends AnyVal
+
+read[FloatValue]("key")
+```
+
+We can also define a shapeless coproduct and load it.
+
+```tut:book
+import shapeless.{:+:, CNil}
+
+type DoubleOrFloat = DoubleValue :+: FloatValue :+: CNil
+
+read[DoubleOrFloat]("key")
+```
+
+If we define a product with more than one value:
+
+```tut:book
+final case class TwoValues(value1: Double, value2: Float)
+```
+
+we will not be able to load it, resulting in an error at compile-time.
+
+```tut:fail:book
+read[TwoValues]("key")
+```
+
+Also, if there's no public constructor or apply method:
+
+```tut:book
+object PrivateValues {
+  final class PrivateFloatValue private(val value: Float) extends AnyVal
+  object PrivateFloatValue {
+    def withValue(value: Float) =
+      new PrivateFloatValue(value)
+  }
+}
+
+import PrivateValues._
+```
+
+we will not be able to load it, again resulting in an error at compile-time.
+
+```tut:fail:book
+read[PrivateFloatValue]("key")
+```
+
+## <a name="refined" href="#refined">Refined</a>
+The `ciris-refined` module allows you to load refinement types from [refined][refined]. Let's start by defining a configuration source from which to read some values.
+
+```tut:book:reset
+import ciris._
+import ciris.refined._
+
+implicit val source = {
+  val keyType = ConfigKeyType("refined key")
+  ConfigSource.fromMap(keyType)(Map(
+    "negative" -> "-1",
+    "zero" -> "0",
+    "positive" -> "1",
+    "other" -> "abc"
+  ))
+}
+```
+
+In this example, we'll simply try to read `PosInt` values, which are all `Int`s strictly greater than zero.
+
+```tut:book
+import eu.timepit.refined.types.numeric.PosInt
+
+read[PosInt]("negative")
+
+read[PosInt]("zero")
+
+read[PosInt]("positive")
+
+read[PosInt]("other")
+```
+
+Refinement types are useful for making sure your configuration is valid. See the [Encoding Validation](/docs/validation) section for more information.
+
+## <a name="squants" href="#squants">Squants</a>
+The `ciris-squants` module allows loading values with unit of measure from [squants][squants]. For a complete list of supported dimensions, refer to the [documentation](/api/ciris/squants). Let's see how this works by first defining a configuration source with a few different keys mapping to `Time` values, each having a different unit of measure.
+
+```tut:book:reset
+import squants.time.Time
+import ciris._
+import ciris.squants._
+
+implicit val source = {
+  val keyType = ConfigKeyType("squants key")
+  ConfigSource.fromMap(keyType)(Map(
+    "seconds" -> "3 s",
+    "minutes" -> "23 m",
+    "hours" -> "12 h"
+  ))
+}
+```
+
+We can then load these values by simply specifying that we want to read values of type `Time`.
+
+```tut:book
+val secondsValue = read[Time]("seconds").value
+
+val minutesValue = read[Time]("minutes").value
+
+val hoursValue = read[Time]("hours").value
+
+for {
+  seconds <- secondsValue
+  minutes <- minutesValue
+  hours <- hoursValue
+} yield (seconds + minutes + hours).toMinutes
+```
+
+[enumeratum]: https://github.com/lloydmeta/enumeratum
+[refined]: https://github.com/fthomas/refined
+[shapeless]: https://github.com/milessabin/shapeless
+[squants]: https://github.com/typelevel/squants

--- a/docs/src/main/tut/docs/readers/readme.md
+++ b/docs/src/main/tut/docs/readers/readme.md
@@ -1,12 +1,12 @@
 ---
 layout: docs
 title: "Custom Readers"
-position: 5
+position: 7
 permalink: /docs/readers
 ---
 
-# Custom Readers
-Ciris already supports reading many standard library types and provides integrations with libraries like [enumeratum][enumeratum], [refined][refined], [shapeless][shapeless], and [squants][squants]. If you're trying to load a standard library type, it is likely that it should be supported by Ciris, so please [file an issue](https://github.com/vlovgr/ciris/issues/new) or, even better, submit a pull-request. The same applies if you're trying to integrate with a library for which Ciris does not already provide a module.
+# <a name="custom-readers" href="#custom-readers">Custom Readers</a>
+Ciris already supports reading many standard library types and provides integrations with libraries like [enumeratum][enumeratum], [refined][refined], and [squants][squants]. If you're trying to load a standard library type, it is likely that it should be supported by Ciris, so please [file an issue](https://github.com/vlovgr/ciris/issues/new) or, even better, submit a pull-request. The same applies if you're trying to integrate with a library for which Ciris does not already provide a module.
 
 However, there may be cases where you need to resort to defining custom readers for your types. For example, let's say you're dealing with a sealed `Odd` class, where you can only construct instances from an `odd` method, which accepts an `Int` and returns an `Option[Odd]`.
 
@@ -35,7 +35,7 @@ implicit def oddConfigReader(implicit intReader: ConfigReader[Int]) =
   intReader.mapOption("Odd")(odd)
 ```
 
-We can then try to read `Odd` values from a custom configuration source.
+We can then try to read `Odd` values from a custom [configuration source](/docs/sources).
 
 ```tut:book
 implicit val source = {
@@ -43,20 +43,19 @@ implicit val source = {
   ConfigSource.fromMap(keyType)(Map("a" -> "abc", "b" -> "6", "c" -> "3"))
 }
 
-val a = read[Odd]("a").value
+val a = read[Odd]("a")
 
-a.left.map(_.message)
+a.value.left.map(_.message)
 
-val b = read[Odd]("b").value
+val b = read[Odd]("b")
 
-b.left.map(_.message)
+b.value.left.map(_.message)
 
-read[Odd]("c").value
+read[Odd]("c")
 ```
 
 While this demonstrates how to create custom `ConfigReader`s, a better way to represent `Odd` values is by using the `Odd` predicate from [refined][refined]. The [Encoding Validation](/docs/validation) section has more information on the `ciris-refined` module and how you can use it to read refined types.
 
 [enumeratum]: https://github.com/lloydmeta/enumeratum
 [refined]: https://github.com/fthomas/refined
-[shapeless]: https://github.com/milessabin/shapeless
-[squants]: http://www.squants.com
+[squants]: https://github.com/typelevel/squants

--- a/docs/src/main/tut/docs/sources/readme.md
+++ b/docs/src/main/tut/docs/sources/readme.md
@@ -1,11 +1,11 @@
 ---
 layout: docs
 title: "Configuration Sources"
-position: 4
+position: 6
 permalink: /docs/sources
 ---
 
-# Configuration Sources
+# <a name="configuration-sources" href="#configuration-sources">Configuration Sources</a>
 Ciris provides support for reading environment variables and system properties. If you're looking for a common configuration source not yet supported, please [file an issue](https://github.com/vlovgr/ciris/issues/new) or, even better, submit a pull-request. If you require other configurations sources, you can easily define your own. You'll find helper methods for creating custom configuration sources in the companion object of [`ConfigSource`](https://cir.is/api/ciris/ConfigSource$.html). Let's illustrate this by writing a configuration source which captures the current system properties at a certain point in time, ignoring any later changes.
 
 To create a configuration source, we need to provide a `ConfigKeyType` which is the name of the type of key the source reads (to support sensible error messages). We can convert the current system properties to a `Map` and create a `ConfigSource` from it using the `fromMap` method. If we make the source implicit and have it in scope, the `read` method will read `ConfigValue` configuration values from it. We can convert a `ConfigValue[T]` to an `Either[ConfigError, T]` by calling the `value` method.
@@ -23,9 +23,9 @@ implicit val fixedProperties = {
   ConfigSource.fromMap(keyType)(sys.props.toMap)
 }
 
-read[String]("file.encoding").value
+read[String]("file.encoding")
 
-prop[String]("file.encoding").value
+prop[String]("file.encoding")
 ```
 
 To verify that the source does not change, let's delete the `file.encoding` key, and verify that we can still read it.
@@ -33,7 +33,7 @@ To verify that the source does not change, let's delete the `file.encoding` key,
 ```tut:book
 sys.props.remove("file.encoding")
 
-read[String]("file.encoding").value
+read[String]("file.encoding")
 
-prop[String]("file.encoding").value
+prop[String]("file.encoding")
 ```

--- a/docs/src/main/tut/docs/validation/readme.md
+++ b/docs/src/main/tut/docs/validation/readme.md
@@ -1,11 +1,11 @@
 ---
 layout: docs
 title: "Encoding Validation"
-position: 2
+position: 4
 permalink: /docs/validation
 ---
 
-# Encoding Validation
+# <a name="encoding-validation" href="#encoding-validation">Encoding Validation</a>
 Ciris intentionally forces you to encode validation in your data types. This means that you have to put more thought into your configurations, and in turn, your domain models. For example, if you want to load an API key, you probably don't want it to be any `String` (not empty) and if you want to load a port value, you probably don't want it to be any `Int` (valid ports are 0 to 65535).
 
 By using more precise types, we get type-safety and a guarantee that values conform to our requirements throughout the application. One of the easiest ways to encode validation in data types is by using [refined][refined]. Ciris provides a `ciris-refined` module which allows you to read any refined type. You can also get compile-time validation for literals from refined (supported by macros).
@@ -26,7 +26,7 @@ final case class Config(
 )
 ```
 
-Here we've said that the API key must be a non-empty `String` and that the port number must be an integer between 0 and 65535. We could also require that the timeout must be finite and within a certain range, but since it's always specified in the code, it's arguably harder to get wrong. Now, let's see how we can simply change the types to read in the `env` and `prop` methods to the refined types, and how Ciris will take care of loading them for you.
+Here we've said that the API key must be a non-empty `String` and that the port number must be an `Int` between 0 and 65535. We could also require that the timeout must be finite and within a certain range, but since it's always specified in the code, it's arguably harder to get wrong. Now, let's see how we can simply change the types to read in the `env` and `prop` methods to the refined types, and how Ciris will take care of loading them for you.
 
 ```tut:book
 import ciris._

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -15,7 +15,7 @@ val scalaPublishVersions: String = {
 
 [![Travis](https://img.shields.io/travis/vlovgr/ciris/master.svg)](https://travis-ci.org/vlovgr/ciris) [![Codecov](https://img.shields.io/codecov/c/github/vlovgr/ciris.svg)](https://codecov.io/gh/vlovgr/ciris) [![Gitter](https://img.shields.io/gitter/room/vlovgr/ciris.svg?colorB=36bc97)](https://gitter.im/vlovgr/ciris) [![Version](https://img.shields.io/maven-central/v/is.cir/ciris-core_2.12.svg?color=blue&label=version)](https://index.scala-lang.org/vlovgr/ciris) [![Documentation](https://img.shields.io/maven-central/v/is.cir/ciris-core_2.12.svg?color=blue&label=docs)](https://cir.is/api)
 
-## Ciris
+## <a name="ciris" href="#ciris">Ciris</a>
 Lightweight, extensible, and validated configuration loading in [Scala][scala] and [Scala.js][scalajs].  
 The core library is dependency-free, while modules provide library integrations.
 
@@ -27,10 +27,10 @@ Ciris' logo was inspired by the epyllion Ciris from [Appendix Vergiliana](https:
 
 Ciris is a new project under active development. Feedback and contributions are welcome.
 
-### Introduction
+### <a name="introduction" href="#introduction">Introduction</a>
 Ciris encourages compile-time safety by defining as much as possible of your configurations in Scala. For the data which cannot reside in code, Ciris helps you to load and decode values, while dealing with errors. Validation is encoded by using appropriate data types, with available integrations to libraries such as [refined][refined] and [squants][squants] to support even more types. Configurations are typically modeled as case class hierarchies, but you are free to choose the model you see fit.
 
-### Getting Started
+### <a name="getting-started" href="#getting-started">Getting Started</a>
 To get started with [SBT][sbt], simply add the following lines to your `build.sbt` file:
 
 ```tut:evaluated
@@ -51,20 +51,22 @@ s"""
 and make sure to replace `%%` with `%%%` if you are using Scala.js.  
 For changes between versions, please refer to the [release notes](https://github.com/vlovgr/ciris/releases).
 
-The only required module is `ciris-core`, the rest are optional modules.
+The only required module is `ciris-core`, the rest are optional library integrations.
 
 - The `ciris-enumeratum` module allows loading [enumeratum][enumeratum] enumerations.
 - The `ciris-generic` module allows loading more types with [shapeless][shapeless].
 - The `ciris-refined` module allows loading [refined][refined] refinement types.
 - The `ciris-squants` module allows loading [squants][squants] data types.
 
+The [Modules Overview](https://cir.is/docs/modules) section explains how to use these modules.
+
 If you're using `ciris-generic` with Scala 2.10, you'll need to include the [Macro Paradise](http://docs.scala-lang.org/overviews/macros/paradise.html) compiler plugin.
 
 ```
-libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
 ```
 
-#### Ammonite
+#### <a name="ammonite" href="#ammonite">Ammonite</a>
 To start an [Ammonite REPL](http://www.lihaoyi.com/Ammonite/#Ammonite-REPL) with Ciris loaded and imported, simply run the following.
 ```
 curl -Ls try.cir.is | sh
@@ -87,27 +89,27 @@ s"""
 )
 ```
 
-### Motivation
+### <a name="motivation" href="#motivation">Motivation</a>
 When it takes little effort to change and release software, for example when employing [continuous deployment](https://www.agilealliance.org/glossary/continuous-deployment/) practices, writing your configurations in Scala can be a viable alternative to configuration files, in order to increase compile-time safety. Since configuration files are not validated at compile-time, any errors will occur at runtime. Tests and macros can be used to perform validation, but by simply using Scala as a configuration language, we ensure that the configuration is correct when compiling, thereby eliminating many potential runtime errors, without having to resort to macros.
 
 For security reasons, it's desirable that secrets, like passwords, are not stored in the source code. For a Scala configuration, this means that the code containing your secrets should be stored in a different place, and later be compiled together with the rest of your application. If you require that your secrets shouldn't be persisted to disk, that might not be feasible. Alternatively, you can define most of your configuration in Scala and only load secrets, and other values which cannot reside in code, from the application's environment.
 
 While it's possible to not use any libraries in the latter case, loading values from the environment typically means dealing with: different environments and configuration sources, type conversions, error handling, and validation. This is where Ciris comes in: a small library, dependency-free at its core, helping you to deal with all of that more easily.
 
-### Documentation
+### <a name="documentation" href="#documentation">Documentation</a>
 For an overview, with examples and explanations of the most common use cases, please refer to the [usage guide](https://cir.is/docs/basics).  
 If you're looking for a more detailed code-centric overview, you can instead take a look at the [API documentation](https://cir.is/api).
 
-### Participation
+### <a name="participation" href="#participation">Participation</a>
 Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](http://typelevel.org/conduct.html). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
 
-### License
+### <a name="license" href="#license">License</a>
 Ciris is available under the MIT license, available at [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT) and in the [license file](https://github.com/vlovgr/ciris/blob/master/license.txt).
 
 [enumeratum]: https://github.com/lloydmeta/enumeratum
 [refined]: https://github.com/fthomas/refined
 [shapeless]: https://github.com/milessabin/shapeless
-[squants]: http://www.squants.com
+[squants]: https://github.com/typelevel/squants
 [sbt]: http://www.scala-sbt.org
 [scala]: http://www.scala-lang.org
 [scalajs]: https://www.scala-js.org

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -3,6 +3,9 @@ package ciris
 sealed abstract class ConfigValue[A] {
   def value: Either[ConfigError, A]
 
+  override def toString: String =
+    s"ConfigValue($value)"
+
   private[ciris] def append[B](next: ConfigValue[B]): ConfigValue2[A, B] = {
     (value, next.value) match {
       case (Right(a), Right(b)) => new ConfigValue2(Right((a, b)))

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -1,0 +1,11 @@
+package ciris
+
+final class ConfigValueSpec extends PropertySpec {
+  "ConfigValue" when {
+    "converting to String" should {
+      "include the value" in {
+        readConfigValue[String]("value").toString shouldBe "ConfigValue(Right(value))"
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -25,8 +25,11 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks {
 
   def fails[A](f: => A): Boolean = Try(f).isFailure
 
+  def readConfigValue[A](value: String)(implicit reader: ConfigReader[A]): ConfigValue[A] =
+    ConfigValue("key")(sourceWith("key" -> value), reader)
+
   def readValue[A](value: String)(implicit reader: ConfigReader[A]): Either[ConfigError, A] =
-    reader.read("key")(sourceWith("key" -> value))
+    readConfigValue[A](value).value
 
   def readNonExistingValue[A](implicit reader: ConfigReader[A]): Either[ConfigError, A] =
     reader.read("key")(sourceWith())


### PR DESCRIPTION
- Add `Core Concepts` and `Modules Overview` sections to usage guide.
- Change headings in the documentation to be hyperlinks with anchors.
- Change links in the usage guide to be underlined when hovered.
   Also use `text-decoration-skip: ink;` throughout microsite.
- The `ConfigValue` class now has a sensible `toString` method.