### PR TITLE
Use WeakTypeTag for refined on JVM

### DIFF
--- a/modules/refined/js/src/main/scala/ciris/refined/readers/RefinedConfigReaders.scala
+++ b/modules/refined/js/src/main/scala/ciris/refined/readers/RefinedConfigReaders.scala
@@ -10,9 +10,9 @@ trait RefinedConfigReaders {
     implicit reader: ConfigReader[T],
     refType: RefType[F],
     validate: Validate[T, P],
-    typeTag: ClassTag[T]
+    classTag: ClassTag[F[T, P]]
   ): ConfigReader[F[T, P]] = {
-    val typeName = implicitly[ClassTag[T]].runtimeClass.getName
+    val typeName = classTag.runtimeClass.getSimpleName
     reader.mapEither(typeName)(refType.refine[P].apply(_))
   }
 }

--- a/modules/refined/jvm/src/main/scala/ciris/refined/readers/RefinedConfigReaders.scala
+++ b/modules/refined/jvm/src/main/scala/ciris/refined/readers/RefinedConfigReaders.scala
@@ -1,0 +1,18 @@
+package ciris.refined.readers
+
+import ciris.ConfigReader
+import eu.timepit.refined.api.{RefType, Validate}
+
+import scala.reflect.runtime.universe.WeakTypeTag
+
+trait RefinedConfigReaders {
+  implicit def refTypeConfigReader[F[_, _], T, P](
+    implicit reader: ConfigReader[T],
+    refType: RefType[F],
+    validate: Validate[T, P],
+    typeTag: WeakTypeTag[F[T, P]]
+  ): ConfigReader[F[T, P]] = {
+    val typeName = typeTag.tpe.toString
+    reader.mapEither(typeName)(refType.refine[P].apply(_))
+  }
+}


### PR DESCRIPTION
The `ciris-refined` module now uses a `WeakTypeTag` on the JVM (still a `ClassTag` on Scala.js).