### PR TITLE
Add support for different key types

### DIFF
--- a/docs/src/main/tut/docs/concepts/readme.md
+++ b/docs/src/main/tut/docs/concepts/readme.md
@@ -6,32 +6,32 @@ permalink: /docs/concepts
 ---
 
 # <a name="core-concepts" href="#core-concepts">Core Concepts</a>
-This section explains the core concepts in Ciris, including the types `ConfigSource`, `ConfigKeyType`, `ConfigReader`, `ConfigError`, `ConfigErrors`, and `ConfigValue` and the methods `loadConfig`, `withValue`, `withValues`, `env`, `prop`, and `read`. For [basic usage](/docs/basics), you do not need to have a complete understanding of these concepts, although it might be helpful. If you need to do some integration with Ciris, like creating a new [module](/docs/modules), defining a new [configuration source](/docs/sources), or writing a [custom reader](/docs/readers) to support new types, understanding these core concepts will be beneficial.
+This section explains the core concepts in Ciris, including the types `ConfigSource`, `ConfigSourceEntry`, `ConfigKeyType`, `ConfigReader`, `ConfigError`, `ConfigErrors`, and `ConfigValue` and the methods `loadConfig`, `withValue`, `withValues`, `env`, `prop`, `arg`, and `read`. For [basic usage](/docs/basics), you do not need to have a complete understanding of these concepts, although it might be helpful. If you need to do some integration with Ciris, like creating a new [module](/docs/modules), defining a new [configuration source](/docs/sources), or writing a [custom reader](/docs/readers) to support new types, understanding these core concepts will be beneficial.
 
 ## <a name="configuration-sources" href="#configuration-sources">Configuration Sources</a>
-Configuration values can be read from different sources, represented by `ConfigSource`s, which are anything that can map `String` keys to `String` values, like `Map[String, String]` for example, and that return a `ConfigError` error if there was an error while reading the value (for example, when no value exists for a given key). A `ConfigSource` reads keys of type `ConfigKeyType`, which is simply a wrapper around the key name, for example `environment variable`. The abstract class `ConfigSource` is defined as follows.
+Configuration values can be read from different sources, represented by `ConfigSource`s, which are anything that can map keys of type `Key` to `String` values, like `Map[Int, String]` for example, and that return a `ConfigError` error if there was an error while reading the value (for example, when no value exists for a given key). A `ConfigSource` reads keys of type `ConfigKeyType`, which is simply a wrapper around the key name and type, for example `environment variable` and type `String`. `ConfigSource` returns a `ConfigSourceEntry`, which is the result of reading a key, including the read key and the `ConfigKeyType`. The abstract class `ConfigSource` is defined as follows.
 
 ```scala
-abstract class ConfigSource(val keyType: ConfigKeyType) {
-  def read(key: String): Either[ConfigError, String]
+abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
+  def read(key: Key): ConfigSourceEntry[Key]
 }
 ```
 
-Ciris provides `ConfigSource`s for environment variables and system properties in the core library. If you require other configuration sources, you can easily create your own. You can read more about `ConfigSource`s in the [Configuration Sources](/docs/sources) section.
+Ciris provides `ConfigSource`s for environment variables, system properties, and command-line arguments in the core library. If you require other configuration sources, you can easily create your own. You can read more about `ConfigSource`s in the [Configuration Sources](/docs/sources) section.
 
 ## <a name="configuration-readers" href="#configuration-readers">Configuration Readers</a>
-Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigReader[A]`. `ConfigReader`s accept an implicit `ConfigSource`, reads values for specified keys, and tries to convert the `String` values into type `A`, returning a `ConfigError` error if the conversion was unsuccessful or if the source could not provide a value for the key. The sealed abstract class `ConfigReader` is defined as follows.
+Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigReader[A]`. `ConfigReader`s accept a `ConfigSourceEntry` from a source and tries to convert the `String` value into type `A`, returning a `ConfigError` error if the conversion was unsuccessful. The abstract class `ConfigReader` is defined as follows.
 
 ```scala
-sealed abstract class ConfigReader[A] {
-  def read(key: String)(implicit source: ConfigSource): Either[ConfigError, A]
+abstract class ConfigReader[Value] {
+  def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, Value]
 }
 ```
 
 Ciris provides `ConfigReader` instances for many types in the standard library, and for third-party library types in separate modules. Modules like `ciris-generic` use [shapeless](https://github.com/milessabin/shapeless) to derive `ConfigReader` instances for certain types, like case classes with one argument and [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html). For more information on Ciris modules, see [Modules Overview](/docs/modules). You can also easily create your own `ConfigReader`s, as described in the [Custom Readers](/docs/readers) section.
 
 ## <a name="configuration-values" href="#configuration-values">Configuration Values</a>
-A configuration value read for a specific key, from a `ConfigSource`, and converted to type `A` using a `ConfigReader[A]`, results in a `ConfigValue[A]`, which is a thin wrapper around an `Either[ConfigError, A]` instance. Ciris provides methods like `env`, `prop`, and `read` for reading `ConfigValue`s from environment variables, system properties, and other configuration sources. `ConfigValue`s are used internally to deal with error accumulation, and when loading configurations you'll typically see `ConfigErrors`, which is the result of error accumulation using `ConfigValue`s.
+A configuration value read for a specific key, from a `ConfigSource`, and converted to type `A` using a `ConfigReader[A]`, results in a `ConfigValue[A]`, which is a thin wrapper around an `Either[ConfigError, A]` instance. Ciris provides methods like `env`, `prop`, `arg`, and `read` for reading `ConfigValue`s from environment variables, system properties, command-line arguments, and other configuration sources. `ConfigValue`s are used internally to deal with error accumulation, and when loading configurations you'll typically see `ConfigErrors`, which is the result of error accumulation using `ConfigValue`s.
 
 ## <a name="loading-configurations" href="#loading-configurations">Loading Configurations</a>
 The `loadConfig` and `withValues` (and `withValue`) methods allow you to combine multiple `ConfigValue`s, while accumulating errors, and using those values to create your configuration. The difference between them is that `withValues` declares a dependency required to be able to use `loadConfig` (think `flatMap`), while `loadConfig` loads your configuration using `ConfigValue`s. The `withValues` method is useful, for example, when dealing with [Multiple Environments](/docs/environments).

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -35,7 +35,7 @@ import ciris.enumeratum._
 import configuration._
 
 implicit val source = {
-  val keyType = ConfigKeyType("enumeratum key")
+  val keyType = ConfigKeyType[String]("enumeratum key")
   ConfigSource.fromMap(keyType)(Map(
     "localEnv" -> "local",
     "testingEnv" -> "testing",
@@ -67,7 +67,7 @@ import ciris._
 import ciris.generic._
 
 implicit val source = {
-  val keyType = ConfigKeyType("generic key")
+  val keyType = ConfigKeyType[String]("generic key")
   ConfigSource.fromMap(keyType)(Map("key" -> "5.0"))
 }
 ```
@@ -138,7 +138,7 @@ import ciris._
 import ciris.refined._
 
 implicit val source = {
-  val keyType = ConfigKeyType("refined key")
+  val keyType = ConfigKeyType[String]("refined key")
   ConfigSource.fromMap(keyType)(Map(
     "negative" -> "-1",
     "zero" -> "0",
@@ -173,7 +173,7 @@ import ciris._
 import ciris.squants._
 
 implicit val source = {
-  val keyType = ConfigKeyType("squants key")
+  val keyType = ConfigKeyType[String]("squants key")
   ConfigSource.fromMap(keyType)(Map(
     "seconds" -> "3 s",
     "minutes" -> "23 m",

--- a/docs/src/main/tut/docs/readers/readme.md
+++ b/docs/src/main/tut/docs/readers/readme.md
@@ -39,7 +39,7 @@ We can then try to read `Odd` values from a custom [configuration source](/docs/
 
 ```tut:book
 implicit val source = {
-  val keyType = ConfigKeyType("int key")
+  val keyType = ConfigKeyType[String]("int key")
   ConfigSource.fromMap(keyType)(Map("a" -> "abc", "b" -> "6", "c" -> "3"))
 }
 

--- a/docs/src/main/tut/docs/sources/readme.md
+++ b/docs/src/main/tut/docs/sources/readme.md
@@ -19,7 +19,7 @@ if(!sys.props.get("file.encoding").isDefined)
 import ciris._
 
 implicit val fixedProperties = {
-  val keyType = ConfigKeyType("fixed system property")
+  val keyType = ConfigKeyType[String]("fixed system property")
   ConfigSource.fromMap(keyType)(sys.props.toMap)
 }
 

--- a/modules/core/shared/src/main/scala/ciris/ConfigError.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigError.scala
@@ -27,13 +27,13 @@ object ConfigError {
     new Combined(Vector(error1, error2) ++ rest) {}
 
   final case class MissingKey(key: String, keyType: ConfigKeyType) extends ConfigError {
-    override def message: String = s"Missing ${keyType.value} [$key]"
+    override def message: String = s"Missing ${keyType.name} [$key]"
   }
 
   final case class ReadException(key: String, keyType: ConfigKeyType, cause: Throwable)
       extends ConfigError {
 
-    override def message: String = s"Exception while reading ${keyType.value} [$key]: $cause"
+    override def message: String = s"Exception while reading ${keyType.name} [$key]: $cause"
   }
 
   final case class WrongType[A, B](
@@ -45,7 +45,7 @@ object ConfigError {
   ) extends ConfigError {
     override def message: String = {
       val causeMessage = cause.map(cause => s": $cause").getOrElse("")
-      s"${keyType.value.capitalize} [$key] with value [$value] cannot be converted to type [$typeName]$causeMessage"
+      s"${keyType.name.capitalize} [$key] with value [$value] cannot be converted to type [$typeName]$causeMessage"
     }
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigError.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigError.scala
@@ -26,22 +26,22 @@ object ConfigError {
   def combined(error1: ConfigError, error2: ConfigError, rest: ConfigError*): Combined =
     new Combined(Vector(error1, error2) ++ rest) {}
 
-  final case class MissingKey(key: String, keyType: ConfigKeyType) extends ConfigError {
+  final case class MissingKey[Key](key: Key, keyType: ConfigKeyType[Key]) extends ConfigError {
     override def message: String = s"Missing ${keyType.name} [$key]"
   }
 
-  final case class ReadException(key: String, keyType: ConfigKeyType, cause: Throwable)
+  final case class ReadException[Key](key: Key, keyType: ConfigKeyType[Key], cause: Throwable)
       extends ConfigError {
 
     override def message: String = s"Exception while reading ${keyType.name} [$key]: $cause"
   }
 
-  final case class WrongType[A, B](
-    key: String,
-    value: A,
+  final case class WrongType[Key, Value, Cause](
+    key: Key,
+    value: Value,
     typeName: String,
-    keyType: ConfigKeyType,
-    cause: Option[B] = None
+    keyType: ConfigKeyType[Key],
+    cause: Option[Cause] = None
   ) extends ConfigError {
     override def message: String = {
       val causeMessage = cause.map(cause => s": $cause").getOrElse("")

--- a/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
@@ -12,4 +12,6 @@ object ConfigKeyType {
   case object Environment extends ConfigKeyType[String]("environment variable")
 
   case object Properties extends ConfigKeyType[String]("system property")
+
+  case object Argument extends ConfigKeyType[Int]("command-line argument")
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
@@ -1,15 +1,15 @@
 package ciris
 
-sealed class ConfigKeyType(val name: String)
+sealed class ConfigKeyType[Key](val name: String)
 
 object ConfigKeyType {
-  def apply(name: String): ConfigKeyType =
-    new ConfigKeyType(name) {
+  def apply[Key](name: String): ConfigKeyType[Key] =
+    new ConfigKeyType[Key](name) {
       override def toString: String =
         s"ConfigKeyType($name)"
     }
 
-  case object Environment extends ConfigKeyType("environment variable")
+  case object Environment extends ConfigKeyType[String]("environment variable")
 
-  case object Properties extends ConfigKeyType("system property")
+  case object Properties extends ConfigKeyType[String]("system property")
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
@@ -1,12 +1,12 @@
 package ciris
 
-sealed class ConfigKeyType(val value: String)
+sealed class ConfigKeyType(val name: String)
 
 object ConfigKeyType {
-  def apply(value: String): ConfigKeyType =
-    new ConfigKeyType(value) {
+  def apply(name: String): ConfigKeyType =
+    new ConfigKeyType(name) {
       override def toString: String =
-        s"ConfigKeyType($value)"
+        s"ConfigKeyType($name)"
     }
 
   case object Environment extends ConfigKeyType("environment variable")

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -5,79 +5,90 @@ import ciris.readers.ConfigReaders
 
 import scala.util.{Failure, Success, Try}
 
-sealed abstract class ConfigReader[A] { self =>
-  def read(key: String)(implicit source: ConfigSource): Either[ConfigError, A]
+abstract class ConfigReader[Value] { self =>
+  def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, Value]
 
-  final def map[B](f: A => B): ConfigReader[B] =
-    ConfigReader.pure { (key, source) =>
-      self.read(key)(source).fold(Left.apply, value => Right(f(value)))
+  final def map[A](f: Value => A): ConfigReader[A] =
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        self.read(entry).fold(Left.apply, value => Right(f(value)))
     }
 
-  final def mapOption[B](typeName: String)(f: A => Option[B]): ConfigReader[B] =
-    ConfigReader.pure { (key, source) =>
-      self
-        .read(key)(source)
-        .fold(Left.apply, value => {
-          f(value) match {
-            case Some(b) => Right(b)
-            case None => Left(WrongType(key, value, typeName, source.keyType))
-          }
-        })
+  final def mapOption[A](typeName: String)(f: Value => Option[A]): ConfigReader[A] =
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        self
+          .read(entry)
+          .fold(Left.apply, value => {
+            f(value) match {
+              case Some(b) => Right(b)
+              case None => Left(WrongType(entry.key, value, typeName, entry.keyType))
+            }
+          })
     }
 
-  final def mapEither[L, R](typeName: String)(f: A => Either[L, R]): ConfigReader[R] =
-    ConfigReader.pure { (key, source) =>
-      self
-        .read(key)(source)
-        .fold(Left.apply, value => {
-          f(value) match {
-            case Right(r) => Right(r)
-            case Left(cause) => Left(WrongType(key, value, typeName, source.keyType, Some(cause)))
-          }
-        })
+  final def mapEither[L, R](typeName: String)(f: Value => Either[L, R]): ConfigReader[R] =
+    new ConfigReader[R] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, R] =
+        self
+          .read(entry)
+          .fold(Left.apply, value => {
+            f(value) match {
+              case Right(r) => Right(r)
+              case Left(cause) =>
+                Left(WrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
+            }
+          })
     }
 }
 
 object ConfigReader extends ConfigReaders {
-  def apply[A](implicit reader: ConfigReader[A]): ConfigReader[A] = reader
+  def apply[Value](implicit reader: ConfigReader[Value]): ConfigReader[Value] = reader
 
-  def pure[A](f: (String, ConfigSource) => Either[ConfigError, A]): ConfigReader[A] =
+  def mapBoth[A](
+    onError: ConfigError => Either[ConfigError, A],
+    onValue: String => Either[ConfigError, A]
+  ): ConfigReader[A] =
     new ConfigReader[A] {
-      override def read(key: String)(implicit source: ConfigSource): Either[ConfigError, A] =
-        f(key, source)
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        entry.value.fold(onError, onValue)
     }
 
-  def fold[A](
-    onMissingKey: ConfigError => Either[ConfigError, A],
-    onValue: (String, String, ConfigSource) => Either[ConfigError, A]
-  ): ConfigReader[A] = pure { (key, source) =>
-    source.read(key).fold(onMissingKey, value => onValue(key, value, source))
-  }
-
-  def withValue[A](f: (String, String, ConfigSource) => Either[ConfigError, A]): ConfigReader[A] =
-    fold(Left.apply, f)
+  def map[A](f: String => Either[ConfigError, A]): ConfigReader[A] =
+    mapBoth(Left.apply, f)
 
   def fromOption[A](typeName: String)(f: String => Option[A]): ConfigReader[A] =
-    withValue { (key, value, source) =>
-      f(value) match {
-        case Some(t) => Right(t)
-        case None => Left(WrongType(key, value, typeName, source.keyType))
-      }
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        entry.value.right.flatMap { value =>
+          f(value) match {
+            case Some(t) => Right(t)
+            case None => Left(WrongType(entry.key, value, typeName, entry.keyType))
+          }
+        }
     }
 
   def fromTry[A](typeName: String)(f: String => Try[A]): ConfigReader[A] =
-    withValue { (key, value, source) =>
-      f(value) match {
-        case Success(a) => Right(a)
-        case Failure(cause) => Left(WrongType(key, value, typeName, source.keyType, Some(cause)))
-      }
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        entry.value.right.flatMap { value =>
+          f(value) match {
+            case Success(a) => Right(a)
+            case Failure(cause) =>
+              Left(WrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
+          }
+        }
     }
 
   def catchNonFatal[A](typeName: String)(f: String => A): ConfigReader[A] =
-    withValue { (key, value, source) =>
-      Try(f(value)) match {
-        case Success(t) => Right(t)
-        case Failure(cause) => Left(WrongType(key, value, typeName, source.keyType, Some(cause)))
-      }
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        entry.value.right.flatMap { value =>
+          Try(f(value)) match {
+            case Success(t) => Right(t)
+            case Failure(cause) =>
+              Left(WrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
+          }
+        }
     }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -54,7 +54,7 @@ object ConfigSource {
     }
 
   case object Environment extends ConfigSource[String](ConfigKeyType.Environment) {
-    val delegate: ConfigSource[String] =
+    private val delegate: ConfigSource[String] =
       ConfigSource.fromMap(keyType)(sys.env)
 
     override def read(key: String): ConfigSourceEntry[String] =
@@ -62,7 +62,7 @@ object ConfigSource {
   }
 
   case object Properties extends ConfigSource[String](ConfigKeyType.Properties) {
-    val delegate: ConfigSource[String] =
+    private val delegate: ConfigSource[String] =
       ConfigSource.fromTryOption(keyType)(key => Try(sys.props.get(key)))
 
     override def read(key: String): ConfigSourceEntry[String] =

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -4,37 +4,37 @@ import ciris.ConfigError.{MissingKey, ReadException}
 
 import scala.util.{Failure, Success, Try}
 
-abstract class ConfigSource(val keyType: ConfigKeyType) {
-  def read(key: String): Either[ConfigError, String]
+abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
+  def read(key: Key): ConfigSourceEntry[Key]
 }
 
 object ConfigSource {
-  def apply(keyType: ConfigKeyType)(read: String => Either[ConfigError, String]): ConfigSource = {
-    val readValue = read
+  def apply[Key](keyType: ConfigKeyType[Key])(read: Key => Either[ConfigError, String]): ConfigSource[Key] = {
+    val entry = (key: Key) => ConfigSourceEntry(key, keyType, read(key))
     new ConfigSource(keyType) {
-      override def read(key: String): Either[ConfigError, String] = readValue(key)
+      override def read(key: Key): ConfigSourceEntry[Key] = entry(key)
       override def toString: String = s"ConfigSource($keyType)"
     }
   }
 
-  def fromOption(keyType: ConfigKeyType)(read: String => Option[String]): ConfigSource =
+  def fromOption[Key](keyType: ConfigKeyType[Key])(read: Key => Option[String]): ConfigSource[Key] =
     ConfigSource(keyType)(key =>
       read(key) match {
         case Some(value) => Right(value)
         case None => Left(MissingKey(key, keyType))
     })
 
-  def fromMap(keyType: ConfigKeyType)(map: Map[String, String]): ConfigSource =
+  def fromMap[Key](keyType: ConfigKeyType[Key])(map: Map[Key, String]): ConfigSource[Key] =
     ConfigSource.fromOption(keyType)(map.get)
 
-  def fromTry(keyType: ConfigKeyType)(read: String => Try[String]): ConfigSource =
+  def fromTry[Key](keyType: ConfigKeyType[Key])(read: Key => Try[String]): ConfigSource[Key] =
     ConfigSource(keyType)(key =>
       read(key) match {
         case Success(value) => Right(value)
         case Failure(cause) => Left(ReadException(key, keyType, cause))
     })
 
-  def fromTryOption(keyType: ConfigKeyType)(read: String => Try[Option[String]]): ConfigSource =
+  def fromTryOption[Key](keyType: ConfigKeyType[Key])(read: Key => Try[Option[String]]): ConfigSource[Key] =
     ConfigSource(keyType)(key =>
       read(key) match {
         case Success(Some(value)) => Right(value)
@@ -42,16 +42,22 @@ object ConfigSource {
         case Failure(cause) => Left(ReadException(key, keyType, cause))
     })
 
-  def catchNonFatal(keyType: ConfigKeyType)(read: String => String): ConfigSource =
+  def catchNonFatal[Key](keyType: ConfigKeyType[Key])(read: Key => String): ConfigSource[Key] =
     ConfigSource.fromTry(keyType)(key => Try(read(key)))
 
-  case object Environment extends ConfigSource(ConfigKeyType.Environment) {
-    override def read(key: String): Either[ConfigError, String] =
-      ConfigSource.fromMap(keyType)(sys.env).read(key)
+  case object Environment extends ConfigSource[String](ConfigKeyType.Environment) {
+    val delegate: ConfigSource[String] =
+      ConfigSource.fromMap(keyType)(sys.env)
+
+    override def read(key: String): ConfigSourceEntry[String] =
+      delegate.read(key)
   }
 
-  case object Properties extends ConfigSource(ConfigKeyType.Properties) {
-    override def read(key: String): Either[ConfigError, String] =
-      ConfigSource.fromTryOption(keyType)(key => Try(sys.props.get(key))).read(key)
+  case object Properties extends ConfigSource[String](ConfigKeyType.Properties) {
+    val delegate: ConfigSource[String] =
+      ConfigSource.fromTryOption(keyType)(key => Try(sys.props.get(key)))
+
+    override def read(key: String): ConfigSourceEntry[String] =
+      delegate.read(key)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -45,6 +45,14 @@ object ConfigSource {
   def catchNonFatal[Key](keyType: ConfigKeyType[Key])(read: Key => String): ConfigSource[Key] =
     ConfigSource.fromTry(keyType)(key => Try(read(key)))
 
+  def byIndex(keyType: ConfigKeyType[Int])(indexedSeq: IndexedSeq[String]): ConfigSource[Int] =
+    ConfigSource.fromOption[Int](keyType){ index =>
+      if(0 <= index && index < indexedSeq.length)
+        Some(indexedSeq(index))
+      else
+        None
+    }
+
   case object Environment extends ConfigSource[String](ConfigKeyType.Environment) {
     val delegate: ConfigSource[String] =
       ConfigSource.fromMap(keyType)(sys.env)

--- a/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
@@ -1,0 +1,7 @@
+package ciris
+
+final case class ConfigSourceEntry[Key](
+  key: Key,
+  keyType: ConfigKeyType[Key],
+  value: Either[ConfigError, String]
+)

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -17,13 +17,13 @@ sealed abstract class ConfigValue[A] {
 }
 
 object ConfigValue {
-  def apply[A](key: String)(
-    implicit source: ConfigSource,
-    reader: ConfigReader[A]
-  ): ConfigValue[A] = {
-    new ConfigValue[A] {
-      override def value: Either[ConfigError, A] =
-        reader.read(key)(source)
+  def apply[Key, Value](key: Key)(
+    implicit source: ConfigSource[Key],
+    reader: ConfigReader[Value]
+  ): ConfigValue[Value] = {
+    new ConfigValue[Value] {
+      override def value: Either[ConfigError, Value] =
+        reader.read[Key](source.read(key))
     }
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigValuePartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValuePartiallyApplied.scala
@@ -1,6 +1,6 @@
 package ciris
 
-final class ConfigValuePartiallyApplied[Value] private[ciris] {
+final class ConfigValuePartiallyApplied[Value] {
   def apply[Key](key: Key)(
     implicit source: ConfigSource[Key],
     reader: ConfigReader[Value]

--- a/modules/core/shared/src/main/scala/ciris/ConfigValuePartiallyApplied.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValuePartiallyApplied.scala
@@ -1,0 +1,9 @@
+package ciris
+
+final class ConfigValuePartiallyApplied[Value] private[ciris] {
+  def apply[Key](key: Key)(
+    implicit source: ConfigSource[Key],
+    reader: ConfigReader[Value]
+  ): ConfigValue[Value] =
+    ConfigValue[Key, Value](key)
+}

--- a/modules/core/shared/src/main/scala/ciris/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/package.scala
@@ -5,6 +5,9 @@ package object ciris extends LoadConfigs {
   def prop[Value: ConfigReader](key: String): ConfigValue[Value] =
     ConfigValue(key)(ConfigSource.Properties, ConfigReader[Value])
 
+  def arg[Value: ConfigReader](args: IndexedSeq[String])(index: Int): ConfigValue[Value] =
+    ConfigValue(index)(ConfigSource.byIndex(ConfigKeyType.Argument)(args), ConfigReader[Value])
+
   def read[Value]: ConfigValuePartiallyApplied[Value] =
     new ConfigValuePartiallyApplied[Value]
 }

--- a/modules/core/shared/src/main/scala/ciris/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/package.scala
@@ -1,10 +1,10 @@
 package object ciris extends LoadConfigs {
-  def env[A: ConfigReader](key: String): ConfigValue[A] =
-    ConfigValue(key)(ConfigSource.Environment, ConfigReader[A])
+  def env[Value: ConfigReader](key: String): ConfigValue[Value] =
+    ConfigValue(key)(ConfigSource.Environment, ConfigReader[Value])
 
-  def prop[A: ConfigReader](key: String): ConfigValue[A] =
-    ConfigValue(key)(ConfigSource.Properties, ConfigReader[A])
+  def prop[Value: ConfigReader](key: String): ConfigValue[Value] =
+    ConfigValue(key)(ConfigSource.Properties, ConfigReader[Value])
 
-  def read[A: ConfigReader](key: String)(implicit source: ConfigSource): ConfigValue[A] =
-    ConfigValue(key)(source, ConfigReader[A])
+  def read[Value]: ConfigValuePartiallyApplied[Value] =
+    new ConfigValuePartiallyApplied[Value]
 }

--- a/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
@@ -1,9 +1,11 @@
 package ciris.readers
 
-import ciris.ConfigReader
-import ciris.ConfigReader.fold
+import ciris.{ConfigError, ConfigReader, ConfigSourceEntry}
 
 trait DerivedConfigReaders {
-  implicit def optionConfigReader[T](implicit reader: ConfigReader[T]): ConfigReader[Option[T]] =
-    fold(_ => Right(None), (key, _, source) => reader.read(key)(source).right.map(Some(_)))
+  implicit def optionConfigReader[Value: ConfigReader]: ConfigReader[Option[Value]] =
+    new ConfigReader[Option[Value]] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, Option[Value]] =
+        entry.value.fold(_ => Right(None), _ => ConfigReader[Value].read(entry).right.map(Some.apply))
+    }
 }

--- a/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/PrimitiveConfigReaders.scala
@@ -1,7 +1,7 @@
 package ciris.readers
 
 import ciris.ConfigReader
-import ciris.ConfigReader.{catchNonFatal, fromOption, withValue}
+import ciris.ConfigReader.{catchNonFatal, fromOption}
 
 trait PrimitiveConfigReaders {
   implicit val booleanConfigReader: ConfigReader[Boolean] =
@@ -37,5 +37,5 @@ trait PrimitiveConfigReaders {
     catchNonFatal("Short")(_.toShort)
 
   implicit val stringConfigReader: ConfigReader[String] =
-    withValue((_, value, _) => Right(value))
+    ConfigReader.map(Right.apply)
 }

--- a/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
+++ b/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
@@ -7,7 +7,7 @@ trait GenericConfigReaders {
   implicit val cNilConfigReader: ConfigReader[CNil] =
     ConfigReader.pure { (key, source) =>
       Left(ConfigError(
-        s"Could not find any valid coproduct choice while reading ${source.keyType.value} [$key]"))
+        s"Could not find any valid coproduct choice while reading ${source.keyType.name} [$key]"))
     }
 
   implicit def coproductConfigReader[A, B <: Coproduct](

--- a/project/SourceGenerators.scala
+++ b/project/SourceGenerators.scala
@@ -279,7 +279,7 @@ object SourceGenerators extends AutoPlugin {
         |final class LoadConfigsSpec extends PropertySpec {
         |  "LoadConfigs" when {
         |    "loading configurations" when {
-        |      implicit val source: ConfigSource = sourceWith("key1" -> "value1", "key2" -> "value2", "key3" -> "value3", "key4" -> "value4", "key5" -> "value5", "key6" -> "value6", "key7" -> "value7", "key8" -> "value8", "key9" -> "value9", "key10" -> "value10", "key11" -> "value11", "key12" -> "value12", "key13" -> "value13", "key14" -> "value14", "key15" -> "value15", "key16" -> "value16", "key17" -> "value17", "key18" -> "value18", "key19" -> "value19", "key20" -> "value20", "key21" -> "value21", "key22" -> "value22")
+        |      implicit val source: ConfigSource[String] = sourceWith("key1" -> "value1", "key2" -> "value2", "key3" -> "value3", "key4" -> "value4", "key5" -> "value5", "key6" -> "value6", "key7" -> "value7", "key8" -> "value8", "key9" -> "value9", "key10" -> "value10", "key11" -> "value11", "key12" -> "value12", "key13" -> "value13", "key14" -> "value14", "key15" -> "value15", "key16" -> "value16", "key17" -> "value17", "key18" -> "value18", "key19" -> "value19", "key20" -> "value20", "key21" -> "value21", "key22" -> "value22")
         |
         |$tests
         |    }

--- a/tests/shared/src/test/scala/ciris/CirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/CirisSpec.scala
@@ -43,5 +43,30 @@ final class CirisSpec extends PropertySpec {
         }
       }
     }
+
+    "loading command-line arguments" should {
+      "be able to load all arguments as string" in {
+        forAll { args: IndexedSeq[String] =>
+          whenever(args.nonEmpty) {
+            forAll(Gen.chooseNum(0, args.length - 1)) { index =>
+              arg[String](args)(index).value shouldBe a[Right[_, _]]
+            }
+          }
+        }
+      }
+
+      "return a failure for non-existing indexes" in {
+        forAll { args: IndexedSeq[String] =>
+          forAll {
+            Gen.oneOf(
+              Gen.chooseNum(Int.MinValue, -1),
+              Gen.chooseNum(args.length, Int.MaxValue)
+            )
+          } { index =>
+            arg[String](args)(index).value shouldBe a[Left[_, _]]
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/shared/src/test/scala/ciris/ConfigSourceSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigSourceSpec.scala
@@ -7,7 +7,7 @@ final class ConfigSourceSpec extends PropertySpec {
     "converting to String" should {
       "include the key type" in {
         forAll { keyType: String =>
-          val configKey = ConfigKeyType(keyType)
+          val configKey = ConfigKeyType[String](keyType)
           ConfigSource(configKey)(Right.apply).toString shouldBe s"ConfigSource($configKey)"
         }
       }
@@ -16,15 +16,15 @@ final class ConfigSourceSpec extends PropertySpec {
     "created from a Try" should {
       "succeed if the Try succeeds" in {
         forAll { (keyType: String, key: String) =>
-          val source = ConfigSource.fromTry(ConfigKeyType(keyType))(key => Try(key))
-          source.read(key) shouldBe Right(key)
+          val source = ConfigSource.fromTry(ConfigKeyType[String](keyType))(key => Try(key))
+          source.read(key).value shouldBe Right(key)
         }
       }
 
       "fail if the Try fails" in {
         forAll { (keyType: String, key: String) =>
-          val source = ConfigSource.fromTry(ConfigKeyType(keyType))(_ => Try(throw new Error))
-          source.read(key) shouldBe a[Left[_, _]]
+          val source = ConfigSource.fromTry(ConfigKeyType[String](keyType))(_ => Try(throw new Error))
+          source.read(key).value shouldBe a[Left[_, _]]
         }
       }
     }
@@ -32,15 +32,15 @@ final class ConfigSourceSpec extends PropertySpec {
     "catching non-fatal exceptions" should {
       "succeed if an exception is not thrown" in {
         forAll { (keyType: String, key: String) =>
-          val source = ConfigSource.catchNonFatal(ConfigKeyType(keyType))(identity)
-          source.read(key) shouldBe Right(key)
+          val source = ConfigSource.catchNonFatal(ConfigKeyType[String](keyType))(identity)
+          source.read(key).value shouldBe Right(key)
         }
       }
 
       "fail if a non-fatal exception is thrown" in {
         forAll { (keyType: String, key: String) =>
-          val source = ConfigSource.catchNonFatal(ConfigKeyType(keyType))(_ => throw new Error)
-          source.read(key) shouldBe a[Left[_, _]]
+          val source = ConfigSource.catchNonFatal(ConfigKeyType[String](keyType))(_ => throw new Error)
+          source.read(key).value shouldBe a[Left[_, _]]
         }
       }
     }

--- a/tests/shared/src/test/scala/ciris/LoadConfigsSpec.scala
+++ b/tests/shared/src/test/scala/ciris/LoadConfigsSpec.scala
@@ -10,7 +10,7 @@ package ciris
 final class LoadConfigsSpec extends PropertySpec {
   "LoadConfigs" when {
     "loading configurations" when {
-      implicit val source: ConfigSource = sourceWith("key1" -> "value1", "key2" -> "value2", "key3" -> "value3", "key4" -> "value4", "key5" -> "value5", "key6" -> "value6", "key7" -> "value7", "key8" -> "value8", "key9" -> "value9", "key10" -> "value10", "key11" -> "value11", "key12" -> "value12", "key13" -> "value13", "key14" -> "value14", "key15" -> "value15", "key16" -> "value16", "key17" -> "value17", "key18" -> "value18", "key19" -> "value19", "key20" -> "value20", "key21" -> "value21", "key22" -> "value22")
+      implicit val source: ConfigSource[String] = sourceWith("key1" -> "value1", "key2" -> "value2", "key3" -> "value3", "key4" -> "value4", "key5" -> "value5", "key6" -> "value6", "key7" -> "value7", "key8" -> "value8", "key9" -> "value9", "key10" -> "value10", "key11" -> "value11", "key12" -> "value12", "key13" -> "value13", "key14" -> "value14", "key15" -> "value15", "key16" -> "value16", "key17" -> "value17", "key18" -> "value18", "key19" -> "value19", "key20" -> "value20", "key21" -> "value21", "key22" -> "value22")
 
       "loading 0 keys" should {
         "always be able to load" in {

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -32,8 +32,8 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks {
     readConfigValue[A](value).value
 
   def readNonExistingValue[A](implicit reader: ConfigReader[A]): Either[ConfigError, A] =
-    reader.read("key")(sourceWith())
+    reader.read(sourceWith().read("key"))
 
-  def sourceWith(entries: (String, String)*): ConfigSource =
-    ConfigSource.fromMap(ConfigKeyType("test key"))(entries.toMap)
+  def sourceWith(entries: (String, String)*): ConfigSource[String] =
+    ConfigSource.fromMap(ConfigKeyType[String]("test key"))(entries.toMap)
 }


### PR DESCRIPTION
* Configuration sources can now be created for different key types.
* Sources and readers are now separated with `ConfigSourceEntry`.
* Add `arg` method for reading command-line arguments by index.

**Miscellaneous**:
* Add `ConfigKeyType#Argument`.
* Rename `ConfigReader#fold` to `mapBoth`.
* Add `ConfigReader#map` and `ConfigSource#byIndex`.
* Fix creating some unnecessary `ConfigSource` instances.
* Remove `ConfigReader#pure` since it can no longer work.
* Add `ConfigValuePartiallyApplied` to support the `read` method.