### PR TITLE
Make sure docs test/compile on cross versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ cache:
   - "$HOME/.sbt/boot/"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION validate
-  - if [[ "$TRAVIS_SCALA_VERSION" == 2.12.* ]]; then sbt validateDocs; fi
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -416,7 +416,7 @@ lazy val moduleNames = List[String]("core", "enumeratum", "generic", "refined", 
 lazy val jsModuleNames = moduleNames.map(_ + "JS")
 lazy val jvmModuleNames = moduleNames.map(_ + "JVM")
 
-addCommandsAlias("docTests", (jsModuleNames ++ jvmModuleNames).map(_ + "/test"))
+addCommandsAlias("docTests", jvmModuleNames.map(_ + "/test"))
 
 lazy val crossModules: Seq[(Project, Project)] =
   Seq(
@@ -439,10 +439,11 @@ def addCommandsAlias(name: String, values: List[String]) =
 
 addCommandsAlias("validate", List(
   "clean",
+  "docTests",
+  "docs/unidoc",
+  "docs/tut",
   "testsJS/test",
   "coverage",
   "testsJVM/test",
   "coverageReport"
 ))
-
-addCommandsAlias("validateDocs", List("docTests", "docs/unidoc", "docs/tut"))

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -74,7 +74,7 @@ implicit val source = {
 
 We can then define and load a unary product, for example a case class with one value.
 
-```tut:book
+```scala
 final case class DoubleValue(value: Double)
 
 read[DoubleValue]("key")
@@ -82,7 +82,7 @@ read[DoubleValue]("key")
 
 It also works for value classes and any other unary products shapeless' `Generic` supports.
 
-```tut:book
+```scala
 final class FloatValue(val value: Float) extends AnyVal
 
 read[FloatValue]("key")
@@ -90,7 +90,7 @@ read[FloatValue]("key")
 
 We can also define a shapeless coproduct and load it.
 
-```tut:book
+```scala
 import shapeless.{:+:, CNil}
 
 type DoubleOrFloat = DoubleValue :+: FloatValue :+: CNil
@@ -189,7 +189,7 @@ val seconds = read[Time]("seconds")
 val minutes = read[Time]("minutes")
 val hours = read[Time]("hours")
 
-loadConfig(seconds, minutes, hours)(_ + _ + _).map(_.toMinutes)
+loadConfig(seconds, minutes, hours)(_ + _ + _).right.map(_.toMinutes)
 ```
 
 [enumeratum]: https://github.com/lloydmeta/enumeratum

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -119,7 +119,7 @@ abstract class ConfigReader[Value] { self =>
     * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("123456", "abc"))
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
-    * scala> val reader = ConfigReader.identity.mapEither("Int")(value => scala.util.Try(value.toInt).fold(Left.apply, Right.apply))
+    * scala> val reader = ConfigReader.identity.mapEither("Int")(value => scala.util.Try(value.toInt).map(Right.apply).recover { case e => Left(e) }.get)
     * reader: ConfigReader[Int] = ConfigReader$$$$anon$$3@8635c89
     *
     * scala> reader.read(source.read(0))


### PR DESCRIPTION
All project documentation (usage guide and API documentation) is now compiled and tested against all `crossScalaVersions`. This required very minor changes in the documentation, except for a few cases of shapeless examples which require macro paradise on 2.10.6. With macro paradise included, the shapeless examples work fine, but refined's auto macro seems to have problems.

```
[tut] *** Error reported at /Users/vlovgr/Projects/ciris/docs/src/main/tut/docs/environments/readme.md:69
// <console>:44: error: exception during macro expansion:
// java.lang.ClassCastException: eu.timepit.refined.BooleanValidate$$anon$2 cannot be cast to eu.timepit.refined.api.Validate
// 	at eu.timepit.refined.macros.RefineMacro.impl(RefineMacro.scala:23)
// 	at eu.timepit.refined.macros.RefineMacro$.impl(RefineMacro.scala:9)
//
//                port = port getOrElse 4000
//                                      ^
```

I've disabled compilation of the shapeless examples until this can be resolved.