### PR TITLE
Add ConfigException and orThrow syntax

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
@@ -99,6 +99,15 @@ final class ConfigErrors private (val toVector: Vector[ConfigError]) extends Any
   def size: Int =
     toVector.size
 
+  /**
+    * Converts this [[ConfigErrors]] to a [[ConfigException]]
+    * which can be thrown.
+    *
+    * @return a new [[ConfigException]]
+    */
+  def toException: ConfigException =
+    ConfigException(this)
+
   override def toString: String =
     s"ConfigErrors(${toVector.mkString(", ")})"
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigException.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigException.scala
@@ -13,7 +13,7 @@ package ciris
   *
   * @param errors the underlying [[ConfigErrors]] of the exception
   */
-final class ConfigException private (errors: ConfigErrors)
+final class ConfigException private (val errors: ConfigErrors)
     extends Throwable({
       val errorCount =
         if (errors.size == 1) "error"

--- a/modules/core/shared/src/main/scala/ciris/ConfigException.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigException.scala
@@ -1,14 +1,14 @@
 package ciris
 
 /**
-  * A [[Throwable]] representation of [[ConfigErrors]]. Useful in cases
+  * A `Throwable` representation of [[ConfigErrors]]. Useful in cases
   * where it's desirable to have failed configuration loading halt
   * program execution - typically during application startup.<br>
   * <br>
   * There's a quick way to convert [[ConfigErrors]] to an exception.
   * {{{
   * scala> ConfigErrors(ConfigError("error1")).toException
-  * res0: ciris.ConfigException = ConfigException(ConfigError(error1))
+  * res0: ConfigException = ConfigException(ConfigError(error1))
   * }}}
   *
   * @param errors the underlying [[ConfigErrors]] of the exception
@@ -40,10 +40,10 @@ object ConfigException {
     * @return a new [[ConfigException]]
     * @example {{{
     * scala> ConfigException(ConfigError("error1") append ConfigError("error2"))
-    * res0: ciris.ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
+    * res0: ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
     *
     * scala> (ConfigError("error1") append ConfigError("error2")).toException
-    * res1: ciris.ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
+    * res1: ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
     * }}}
     */
   def apply(errors: ConfigErrors): ConfigException =

--- a/modules/core/shared/src/main/scala/ciris/ConfigException.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigException.scala
@@ -1,0 +1,51 @@
+package ciris
+
+/**
+  * A [[Throwable]] representation of [[ConfigErrors]]. Useful in cases
+  * where it's desirable to have failed configuration loading halt
+  * program execution - typically during application startup.<br>
+  * <br>
+  * There's a quick way to convert [[ConfigErrors]] to an exception.
+  * {{{
+  * scala> ConfigErrors(ConfigError("error1")).toException
+  * res0: ciris.ConfigException = ConfigException(ConfigError(error1))
+  * }}}
+  *
+  * @param errors the underlying [[ConfigErrors]] of the exception
+  */
+final class ConfigException private (errors: ConfigErrors)
+    extends Throwable({
+      val errorCount =
+        if (errors.size == 1) "error"
+        else s"[${errors.size}] errors"
+
+      val errorMessages =
+        errors.toVector
+          .map(error => s"  - ${error.message}.")
+          .mkString("\n", "\n", "\n")
+
+      s"configuration loading failed with the following $errorCount.\n$errorMessages"
+    }) {
+
+  override def toString: String =
+    s"ConfigException(${errors.toVector.mkString(", ")})"
+}
+
+object ConfigException {
+
+  /**
+    * Creates a new [[ConfigException]] using the specified [[ConfigErrors]].
+    *
+    * @param errors the [[ConfigErrors]] from which to create the exception
+    * @return a new [[ConfigException]]
+    * @example {{{
+    * scala> ConfigException(ConfigError("error1") append ConfigError("error2"))
+    * res0: ciris.ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
+    *
+    * scala> (ConfigError("error1") append ConfigError("error2")).toException
+    * res1: ciris.ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
+    * }}}
+    */
+  def apply(errors: ConfigErrors): ConfigException =
+    new ConfigException(errors)
+}

--- a/modules/core/shared/src/main/scala/ciris/syntax.scala
+++ b/modules/core/shared/src/main/scala/ciris/syntax.scala
@@ -1,7 +1,7 @@
 package ciris
 
 object syntax {
-  implicit def eitherConfigErrorsOps[T](
+  implicit def eitherConfigErrorsSyntax[T](
     either: Either[ConfigErrors, T]
   ): EitherConfigErrorsSyntax[T] = {
     new EitherConfigErrorsSyntax(either)

--- a/modules/core/shared/src/main/scala/ciris/syntax.scala
+++ b/modules/core/shared/src/main/scala/ciris/syntax.scala
@@ -1,0 +1,26 @@
+package ciris
+
+object syntax {
+  implicit def eitherConfigErrorsOps[T](
+    either: Either[ConfigErrors, T]
+  ): EitherConfigErrorsSyntax[T] = {
+    new EitherConfigErrorsSyntax(either)
+  }
+
+  final class EitherConfigErrorsSyntax[T](val either: Either[ConfigErrors, T]) extends AnyVal {
+
+    /**
+      * If the configuration was loaded successfully, returns the
+      * configuration; otherwise, an exception is thrown with a
+      * message detailing why the the loading failed.
+      *
+      * @return the configuration, or an exception if the
+      *         configuration failed to load
+      */
+    def orThrow(): T =
+      either.fold(
+        errors => throw errors.toException,
+        identity
+      )
+  }
+}

--- a/tests/shared/src/test/scala/ciris/CirisSyntaxSpec.scala
+++ b/tests/shared/src/test/scala/ciris/CirisSyntaxSpec.scala
@@ -1,0 +1,31 @@
+package ciris
+
+import ciris.syntax._
+
+final class CirisSyntaxSpec extends PropertySpec {
+  "Syntax" when {
+    "using orThrow" should {
+      "return the configuration if loaded successfully" in {
+        val config = loadConfig(
+          readConfigValue[String]("key1"),
+          readConfigValue[String]("key2")
+        )(_ + _)
+
+        noException shouldBe thrownBy {
+          config.orThrow()
+        }
+      }
+
+      "throw an exception if loading failed" in {
+        val config = loadConfig(
+          readConfigValue[String]("key1"),
+          readNonExistingConfigValue[String]
+        )(_ + _)
+
+        a[ConfigException] shouldBe thrownBy {
+          config.orThrow()
+        }
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/CirisSyntaxSpec.scala
+++ b/tests/shared/src/test/scala/ciris/CirisSyntaxSpec.scala
@@ -3,7 +3,7 @@ package ciris
 import ciris.syntax._
 
 final class CirisSyntaxSpec extends PropertySpec {
-  "Syntax" when {
+  "Ciris syntax" when {
     "using orThrow" should {
       "return the configuration if loaded successfully" in {
         val config = loadConfig(

--- a/tests/shared/src/test/scala/ciris/ConfigErrorsSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigErrorsSpec.scala
@@ -32,5 +32,15 @@ final class ConfigErrorsSpec extends PropertySpec {
         )
       }
     }
+
+    "converting to exception" should {
+      "be able to retrieve the original errors" in {
+        val configErrors =
+          ConfigErrors(missingKey("key", ConfigKeyType.Environment))
+            .append(readException("key2", ConfigKeyType.Property, new Error("error")))
+
+        configErrors.toException.errors shouldBe configErrors
+      }
+    }
   }
 }

--- a/tests/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
@@ -1,0 +1,49 @@
+package ciris
+
+final class ConfigExceptionSpec extends PropertySpec {
+  "ConfigException" when {
+    "converting to String" should {
+      "include the errors" in {
+        val configException =
+          ConfigErrors(ConfigError.missingKey("key", ConfigKeyType.Environment))
+            .append(ConfigError.readException("key", ConfigKeyType.Property, new Error("error")))
+            .toException
+
+        configException.toString shouldBe "ConfigException(MissingKey(key, Environment), ReadException(key, Property, java.lang.Error: error))"
+      }
+    }
+
+    "retrieving the message" when {
+      "there is a single error" should {
+        "list the single error" in {
+          val configException =
+            ConfigErrors(ConfigError.missingKey("key", ConfigKeyType.Environment)).toException
+
+          configException.getMessage.trim shouldBe
+            """
+              |configuration loading failed with the following error.
+              |
+              |  - Missing environment variable [key].
+            """.stripMargin.trim
+        }
+      }
+
+      "there are multiple errors" should {
+        "list all the errors" in {
+          val configException =
+            ConfigErrors(ConfigError.missingKey("key", ConfigKeyType.Environment))
+              .append(ConfigError.readException("key", ConfigKeyType.Property, new Error("error")))
+              .toException
+
+          configException.getMessage.trim shouldBe
+            """
+              |configuration loading failed with the following [2] errors.
+              |
+              |  - Missing environment variable [key].
+              |  - Exception while reading system property [key]: java.lang.Error: error.
+            """.stripMargin.trim
+        }
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -31,6 +31,9 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks {
   def readValue[A](value: String)(implicit reader: ConfigReader[A]): Either[ConfigError, A] =
     readConfigValue[A](value).value
 
+  def readNonExistingConfigValue[A](implicit reader: ConfigReader[A]): ConfigValue[A] =
+    ConfigValue("key")(emptySource, reader)
+
   def readNonExistingValue[A](implicit reader: ConfigReader[A]): Either[ConfigError, A] =
     reader.read(emptySource.read("key"))
 


### PR DESCRIPTION
- Add `ConfigException` throwable, wrapping `ConfigErrors`.
- Add `ConfigErrors#toException` for converting to `ConfigException`.
- Add `Either[ConfigErrors, T]#orThrow()` syntax in the `syntax` package.

This allows for a convenient way to have failed configuration loading halt program execution - typically during application startup.

```
scala> import ciris._, ciris.syntax._
import ciris._
import ciris.syntax._

scala> loadConfig(env[String]("HOME"))(identity).orThrow()
res0: String = /Users/vlovgr

scala> loadConfig(env[String]("API_KEY"))(identity).orThrow()
ciris.ConfigException: configuration loading failed with the following error.

  - Missing environment variable [API_KEY].

  at ciris.ConfigException$.apply(ConfigException.scala:50)
  at ciris.ConfigErrors$.toException$extension(ConfigErrors.scala:109)
  at ciris.syntax$EitherConfigErrorsSyntax$.$anonfun$orThrow$1(syntax.scala:22)
  at ciris.syntax$EitherConfigErrorsSyntax$.$anonfun$orThrow$1$adapted(syntax.scala:22)
  at scala.util.Either.fold(Either.scala:189)
  at ciris.syntax$EitherConfigErrorsSyntax$.orThrow$extension(syntax.scala:23)
```