### PR TITLE
Add spire module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -367,7 +367,7 @@ generateScripts in ThisBuild := {
        |)
        |
        |~/.coursier/coursier launch -q -P \\
-       |  com.lihaoyi:ammonite_2.12.3:1.0.1 \\
+       |  com.lihaoyi:ammonite_2.12.3:1.0.2 \\
        |  $organizationId:${(moduleName in coreJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in enumeratumJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in genericJVM).value}_2.12:$moduleVersion \\

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val ciris = project
     enumeratumJS, enumeratumJVM,
     genericJS, genericJVM,
     refinedJS, refinedJVM,
+    spireJS, spireJVM,
     squantsJS, squantsJVM,
     testsJS, testsJVM
   )
@@ -68,6 +69,19 @@ lazy val refined = crossProject
 lazy val refinedJS = refined.js
 lazy val refinedJVM = refined.jvm
 
+lazy val spire = crossProject
+  .in(file("modules/spire"))
+  .settings(moduleName := "ciris-spire", name := "Ciris spire")
+  .settings(libraryDependencies += "org.typelevel" %%% "spire" % "0.14.1")
+  .settings(scalaSettings)
+  .settings(testSettings)
+  .jsSettings(jsTestSettings)
+  .settings(releaseSettings)
+  .dependsOn(core)
+
+lazy val spireJS = spire.js
+lazy val spireJVM = spire.jvm
+
 lazy val squants = crossProject
   .in(file("modules/squants"))
   .settings(moduleName := "ciris-squants", name := "Ciris squants")
@@ -89,7 +103,7 @@ lazy val tests = crossProject
   .settings(noPublishSettings)
   .settings(testSettings)
   .jsSettings(jsTestSettings)
-  .dependsOn(core, enumeratum, generic, refined, squants)
+  .dependsOn(core, enumeratum, generic, refined, spire, squants)
 
 lazy val testsJS = tests.js
 lazy val testsJVM = tests.jvm
@@ -134,6 +148,7 @@ lazy val docs = project
       BuildInfoKey.map(moduleName in enumeratumJVM) { case (k, v) => "enumeratum" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in genericJVM) { case (k, v) => "generic" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in refinedJVM) { case (k, v) => "refined" + k.capitalize -> v },
+      BuildInfoKey.map(moduleName in spireJVM) { case (k, v) => "spire" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in squantsJVM) { case (k, v) => "squants" + k.capitalize -> v }
     )
   )
@@ -154,6 +169,7 @@ lazy val docs = project
           | - The [[ciris.enumeratum enumeratum]] module integrates with [[https://github.com/lloydmeta/enumeratum enumeratum]] to be able to read enumerations.
           | - The [[ciris.generic generic]] module uses [[https://github.com/milessabin/shapeless shapeless]] to be able to read unary products, and coproducts.
           | - The [[ciris.refined refined]] module integrates with [[https://github.com/fthomas/refined refined]] to be able to read refinement types.
+          | - The [[ciris.spire spire]] module integrates with [[https://github.com/non/spire spire]] to be able to read more number types.
           | - The [[ciris.squants squants]] module integrates with [[https://github.com/typelevel/squants squants]] to read values with unit of measure.
           |
           |If you're looking for usage instructions, please refer to the [[https://cir.is/docs/basics usage guide]].
@@ -174,7 +190,7 @@ lazy val docs = project
       "-doc-root-content", (generateApiIndexFile.value).getAbsolutePath
     )
   )
-  .dependsOn(coreJVM, enumeratumJVM, genericJVM, refinedJVM, squantsJVM)
+  .dependsOn(coreJVM, enumeratumJVM, genericJVM, refinedJVM, spireJVM, squantsJVM)
   .enablePlugins(BuildInfoPlugin, MicrositesPlugin, ScalaUnidocPlugin)
 
 lazy val scala210 = "2.10.6"
@@ -356,8 +372,9 @@ generateScripts in ThisBuild := {
        |  $organizationId:${(moduleName in enumeratumJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in genericJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in refinedJVM).value}_2.12:$moduleVersion \\
+       |  $organizationId:${(moduleName in spireJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in squantsJVM).value}_2.12:$moduleVersion \\
-       |  -- --predef-code 'import ciris._,ciris.enumeratum._,ciris.generic._,ciris.refined._,ciris.squants._' < /dev/tty
+       |  -- --predef-code 'import ciris._,ciris.enumeratum._,ciris.generic._,ciris.refined._,ciris.spire._,ciris.squants._' < /dev/tty
      """.stripMargin.trim + "\n"
 
   IO.createDirectory(output)
@@ -410,7 +427,7 @@ addDateToReleaseNotes in ThisBuild := {
   }
 }
 
-lazy val moduleNames = List[String]("core", "enumeratum", "generic", "refined", "squants")
+lazy val moduleNames = List[String]("core", "enumeratum", "generic", "refined", "spire", "squants")
 lazy val jsModuleNames = moduleNames.map(_ + "JS")
 lazy val jvmModuleNames = moduleNames.map(_ + "JVM")
 
@@ -422,6 +439,7 @@ lazy val crossModules: Seq[(Project, Project)] =
     (enumeratumJVM, enumeratumJS),
     (genericJVM, genericJS),
     (refinedJVM, refinedJS),
+    (spireJVM, spireJS),
     (squantsJVM, squantsJS)
   )
 

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -164,6 +164,43 @@ read[PosInt]("other")
 
 Refinement types are useful for making sure your configuration is valid. See the [Encoding Validation](/docs/validation) section for more information.
 
+## <a name="spire" href="#spire">Spire</a>
+The `ciris-spire` module adds support for loading [spire][spire] number types. For a complete list of support number types, refer to the [documentation](/api/ciris/spire). Let's see how we can load spire number types by first defining a custom configuration source.
+
+```tut:book:reset
+import spire.math._
+import ciris._
+import ciris.spire._
+
+implicit val source = {
+  val keyType = ConfigKeyType[String]("spire key")
+  ConfigSource.fromEntries(keyType)(
+    "natural" -> "847365894625891365137596378546725",
+    "interval" -> "(1/3, 524/51]",
+    "rational" -> "-194712/-129831",
+    "uint" -> (Int.MaxValue.toLong + 1L).toString
+  )
+}
+```
+
+We can then simply read values from the source using `read` and by specifying spire number types.
+
+```tut:book
+read[Natural]("natural")
+
+read[Interval[Rational]]("interval")
+
+read[Rational]("rational")
+
+read[Number]("natural")
+
+read[Real]("rational")
+
+read[Trilean]("trilean")
+
+read[UInt]("uint")
+```
+
 ## <a name="squants" href="#squants">Squants</a>
 The `ciris-squants` module allows loading values with unit of measure from [squants][squants]. For a complete list of supported dimensions, refer to the [documentation](/api/ciris/squants). Let's see how this works by first defining a configuration source with a few different keys mapping to `Time` values, each having a different unit of measure.
 
@@ -195,4 +232,5 @@ loadConfig(seconds, minutes, hours)(_ + _ + _).right.map(_.toMinutes)
 [enumeratum]: https://github.com/lloydmeta/enumeratum
 [refined]: https://github.com/fthomas/refined
 [shapeless]: https://github.com/milessabin/shapeless
+[spire]: https://github.com/non/spire
 [squants]: https://github.com/typelevel/squants

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -47,6 +47,7 @@ s"""
  |  "$organization" %% "$enumeratumModuleName" % "$latestVersion",
  |  "$organization" %% "$genericModuleName" % "$latestVersion",
  |  "$organization" %% "$refinedModuleName" % "$latestVersion",
+ |  "$organization" %% "$spireModuleName" % "$latestVersion"
  |  "$organization" %% "$squantsModuleName" % "$latestVersion"
  |)
  """.stripMargin.trim
@@ -62,6 +63,7 @@ For an explanation of how to use the modules, see the [Modules Overview](https:/
 - The `ciris-enumeratum` module allows loading [enumeratum][enumeratum] enumerations.
 - The `ciris-generic` module allows loading more types with [shapeless][shapeless].
 - The `ciris-refined` module allows loading [refined][refined] refinement types.
+- The `ciris-spire` module allows loading [spire][spire] number types.
 - The `ciris-squants` module allows loading [squants][squants] data types.
 
 If you're using `ciris-generic` with Scala 2.10, you'll need to include the [Macro Paradise](http://docs.scala-lang.org/overviews/macros/paradise.html) compiler plugin.
@@ -88,6 +90,7 @@ s"""
  |import $$ivy.`$organization::$enumeratumModuleName:$latestVersion`, ciris.enumeratum._
  |import $$ivy.`$organization::$genericModuleName:$latestVersion`, ciris.generic._
  |import $$ivy.`$organization::$refinedModuleName:$latestVersion`, ciris.refined._
+ |import $$ivy.`$organization::$spireModuleName:$latestVersion`, ciris.spire._
  |import $$ivy.`$organization::$squantsModuleName:$latestVersion`, ciris.squants._
  """.stripMargin.trim
 )
@@ -113,6 +116,7 @@ Ciris is available under the MIT license, available at [https://opensource.org/l
 [enumeratum]: https://github.com/lloydmeta/enumeratum
 [refined]: https://github.com/fthomas/refined
 [shapeless]: https://github.com/milessabin/shapeless
+[spire]: https://github.com/non/spire
 [squants]: https://github.com/typelevel/squants
 [sbt]: http://www.scala-sbt.org
 [scala]: http://www.scala-lang.org

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -47,7 +47,7 @@ s"""
  |  "$organization" %% "$enumeratumModuleName" % "$latestVersion",
  |  "$organization" %% "$genericModuleName" % "$latestVersion",
  |  "$organization" %% "$refinedModuleName" % "$latestVersion",
- |  "$organization" %% "$spireModuleName" % "$latestVersion"
+ |  "$organization" %% "$spireModuleName" % "$latestVersion",
  |  "$organization" %% "$squantsModuleName" % "$latestVersion"
  |)
  """.stripMargin.trim

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -118,7 +118,7 @@ abstract class ConfigReader[Value] { self =>
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader.identity.mapTry("Int")(value => scala.util.Try(value.toInt))
-    * reader: ConfigReader[Int] = ConfigReader$$anon$3@380729e4
+    * reader: ConfigReader[Int] = ConfigReader$$$$anon$$3@380729e4
     *
     * scala> reader.read(source.read(0))
     * res0: Either[ConfigError,Int] = Right(123456)
@@ -159,7 +159,7 @@ abstract class ConfigReader[Value] { self =>
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader.identity.mapCatchNonFatal("Int")(_.toInt)
-    * reader: ConfigReader[Int] = ConfigReader$$anon$3@17323c05
+    * reader: ConfigReader[Int] = ConfigReader$$$$anon$$3@17323c05
     *
     * scala> reader.read(source.read(0))
     * res0: Either[ConfigError,Int] = Right(123456)
@@ -187,7 +187,7 @@ abstract class ConfigReader[Value] { self =>
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader.identity.collect("PosBigInt") { case s if s.forall(_.isDigit) => BigInt(s) }
-    * reader: ConfigReader[scala.math.BigInt] = ConfigReader$$anon$2@727cfc59
+    * reader: ConfigReader[scala.math.BigInt] = ConfigReader$$$$anon$$2@727cfc59
     *
     * scala> reader.read(source.read(0))
     * res0: Either[ConfigError,scala.math.BigInt] = Right(123456)
@@ -427,7 +427,7 @@ object ConfigReader extends ConfigReaders {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader.fromTryOption("Int")(value => scala.util.Try(if(value.length == 3) Some(value.toInt) else None))
-    * reader: ConfigReader[Int] = ConfigReader$$anon$9@7d20803b
+    * reader: ConfigReader[Int] = ConfigReader$$$$anon$$9@7d20803b
     *
     * scala> reader.read(source.read(0))
     * res0: Either[ConfigError,Int] = Right(1)

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -97,11 +97,82 @@ abstract class ConfigReader[Value] { self =>
           .read(entry)
           .fold(Left.apply, value => {
             f(value) match {
-              case Some(b) => Right(b)
-              case None => Left(wrongType(entry.key, value, typeName, entry.keyType))
+              case Some(a) => Right(a)
+              case None    => Left(wrongType(entry.key, value, typeName, entry.keyType))
             }
           })
     }
+
+  /**
+    * Applies a function on the converted value, returning a `Try[A]`.
+    * If the function returns a `Success`, the type conversion will
+    * be considered successful. Returning a `Failure` means that
+    * the conversion failed.
+    *
+    * @param typeName the name of the type `A`
+    * @param f the function converting from `Value` to `Try[A]`
+    * @tparam A the type for which to convert the value to
+    * @return a new `ConfigReader[A]`
+    * @example {{{
+    * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("123456", "abc"))
+    * source: ConfigSource[Int] = ConfigSource(Argument)
+    *
+    * scala> val reader = ConfigReader.identity.mapTry("Int")(value => scala.util.Try(value.toInt))
+    * reader: ConfigReader[Int] = ConfigReader$$anon$3@380729e4
+    *
+    * scala> reader.read(source.read(0))
+    * res0: Either[ConfigError,Int] = Right(123456)
+    *
+    * scala> reader.read(source.read(1))
+    * res1: Either[ConfigError,Int] = Left(WrongType(1, abc, Int, Argument, Some(java.lang.NumberFormatException: For input string: "abc")))
+    *
+    * scala> reader.read(source.read(2))
+    * res2: Either[ConfigError,Int] = Left(MissingKey(2, Argument))
+    * }}}
+    */
+  final def mapTry[A](typeName: String)(f: Value => Try[A]): ConfigReader[A] =
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        self
+          .read(entry)
+          .fold(Left.apply, value => {
+            f(value) match {
+              case Success(a) => Right(a)
+              case Failure(cause) =>
+                Left(wrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
+            }
+          })
+    }
+
+  /**
+    * Applies a function on the converted value to `A`, making sure to catch
+    * any non-fatal exceptions thrown by the function. The conversion will
+    * be considered successful only if the function does not throw an
+    * exception.
+    *
+    * @param typeName the name of the type `A`
+    * @param f the function converting from `Value` to `A`
+    * @tparam A the type for which to convert the value to
+    * @return a new `ConfigReader[A]`
+    * @example {{{
+    * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("123456", "abc"))
+    * source: ConfigSource[Int] = ConfigSource(Argument)
+    *
+    * scala> val reader = ConfigReader.identity.mapCatchNonFatal("Int")(_.toInt)
+    * reader: ConfigReader[Int] = ConfigReader$$anon$3@17323c05
+    *
+    * scala> reader.read(source.read(0))
+    * res0: Either[ConfigError,Int] = Right(123456)
+    *
+    * scala> reader.read(source.read(1))
+    * res1: Either[ConfigError,Int] = Left(WrongType(1, abc, Int, Argument, Some(java.lang.NumberFormatException: For input string: "abc")))
+    *
+    * scala> reader.read(source.read(2))
+    * res2: Either[ConfigError,Int] = Left(MissingKey(2, Argument))
+    * }}}
+    */
+  final def mapCatchNonFatal[A](typeName: String)(f: Value => A): ConfigReader[A] =
+    mapTry(typeName)(value => Try(f(value)))
 
   /**
     * Applies a partial function on the converted value. The type conversion to
@@ -116,16 +187,16 @@ abstract class ConfigReader[Value] { self =>
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader.identity.collect("PosBigInt") { case s if s.forall(_.isDigit) => BigInt(s) }
-    * reader: ciris.ConfigReader[scala.math.BigInt] = ciris.ConfigReader$$anon$2@727cfc59
+    * reader: ConfigReader[scala.math.BigInt] = ConfigReader$$anon$2@727cfc59
     *
     * scala> reader.read(source.read(0))
-    * res0: Either[ciris.ConfigError,scala.math.BigInt] = Right(123456)
+    * res0: Either[ConfigError,scala.math.BigInt] = Right(123456)
     *
     * scala> reader.read(source.read(1))
-    * res1: Either[ciris.ConfigError,scala.math.BigInt] = Left(WrongType(1, -123, PosBigInt, Argument, None))
+    * res1: Either[ConfigError,scala.math.BigInt] = Left(WrongType(1, -123, PosBigInt, Argument, None))
     *
     * scala> reader.read(source.read(2))
-    * res2: Either[ciris.ConfigError,scala.math.BigInt] = Left(MissingKey(2, Argument))
+    * res2: Either[ConfigError,scala.math.BigInt] = Left(MissingKey(2, Argument))
     * }}}
     */
   final def collect[A](typeName: String)(f: PartialFunction[Value, A]): ConfigReader[A] =
@@ -300,7 +371,7 @@ object ConfigReader extends ConfigReaders {
         entry.value.right.flatMap { value =>
           f(value) match {
             case Some(t) => Right(t)
-            case None => Left(wrongType(entry.key, value, typeName, entry.keyType))
+            case None    => Left(wrongType(entry.key, value, typeName, entry.keyType))
           }
         }
     }
@@ -335,6 +406,49 @@ object ConfigReader extends ConfigReaders {
         entry.value.right.flatMap { value =>
           f(value) match {
             case Success(a) => Right(a)
+            case Failure(cause) =>
+              Left(wrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
+          }
+        }
+    }
+
+  /**
+    * Creates a new [[ConfigReader]] by applying a function in the case
+    * when a value was successfully read from the configuration source,
+    * returning a `Try[Option[A]]`. The conversion will only succeed
+    * if the function returns `Success[Some[A]]`.
+    *
+    * @param typeName the name of the type `A`
+    * @param f the function to apply on the value, returning `Try[Option[A]]`
+    * @tparam A the type to convert to
+    * @return a new `ConfigReader[A]`
+    * @example {{{
+    * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("1", "1234", "a"))
+    * source: ConfigSource[Int] = ConfigSource(Argument)
+    *
+    * scala> val reader = ConfigReader.fromTryOption("Int")(value => scala.util.Try(if(value.length == 3) Some(value.toInt) else None))
+    * reader: ConfigReader[Int] = ConfigReader$$anon$9@7d20803b
+    *
+    * scala> reader.read(source.read(0))
+    * res0: Either[ConfigError,Int] = Right(1)
+    *
+    * scala> reader.read(source.read(1))
+    * res1: Either[ConfigError,Int] = Left(WrongType(1, 1234, Int, Argument, None))
+    *
+    * scala> reader.read(source.read(2))
+    * res2: Either[ConfigError,Int] = Left(WrongType(1, a, Int, Argument, Some(java.lang.NumberFormatException: For input string: "a")))
+    *
+    * scala> reader.read(source.read(3))
+    * res3: Either[ConfigError,Int] = Left(MissingKey(3, Argument))
+    * }}}
+    */
+  def fromTryOption[A](typeName: String)(f: String => Try[Option[A]]): ConfigReader[A] =
+    new ConfigReader[A] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, A] =
+        entry.value.right.flatMap { value =>
+          f(value) match {
+            case Success(Some(value)) => Right(value)
+            case Success(None)        => Left(wrongType(entry.key, value, typeName, entry.keyType))
             case Failure(cause) =>
               Left(wrongType(entry.key, value, typeName, entry.keyType, Some(cause)))
           }

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -426,7 +426,7 @@ object ConfigReader extends ConfigReaders {
     * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("1", "1234", "a"))
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
-    * scala> val reader = ConfigReader.fromTryOption("Int")(value => scala.util.Try(if(value.length == 3) Some(value.toInt) else None))
+    * scala> val reader = ConfigReader.fromTryOption("Int")(value => scala.util.Try(if(value.length < 4) Some(value.toInt) else None))
     * reader: ConfigReader[Int] = ConfigReader$$$$anon$$9@7d20803b
     *
     * scala> reader.read(source.read(0))
@@ -436,7 +436,7 @@ object ConfigReader extends ConfigReaders {
     * res1: Either[ConfigError,Int] = Left(WrongType(1, 1234, Int, Argument, None))
     *
     * scala> reader.read(source.read(2))
-    * res2: Either[ConfigError,Int] = Left(WrongType(1, a, Int, Argument, Some(java.lang.NumberFormatException: For input string: "a")))
+    * res2: Either[ConfigError,Int] = Left(WrongType(2, a, Int, Argument, Some(java.lang.NumberFormatException: For input string: "a")))
     *
     * scala> reader.read(source.read(3))
     * res3: Either[ConfigError,Int] = Left(MissingKey(3, Argument))

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -134,6 +134,33 @@ object ConfigSource {
 
   /**
     * Creates a new [[ConfigSource]] from the specified [[ConfigKeyType]]
+    * and entries with keys of type `Key`. If the same key appears more
+    * than once in the entries, the last one will be chosen to be
+    * included in the source.
+    *
+    * @param keyType the [[ConfigKeyType]] representing the key type and name
+    * @param entries the entries to be included in the source
+    * @tparam Key the type of keys which the source supports
+    * @return a new [[ConfigSource]] using the specified arguments
+    * @example {{{
+    * scala> val source = ConfigSource.fromEntries(ConfigKeyType.Argument)(0 -> "abc", 0 -> "def", 1 -> "ghi")
+    * source: ConfigSource[Int] = ConfigSource(Argument)
+    *
+    * scala> source.read(0)
+    * res0: ConfigSourceEntry[Int] = ConfigSourceEntry(0, Argument, Right(def))
+    *
+    * scala> source.read(1)
+    * res1: ConfigSourceEntry[Int] = ConfigSourceEntry(1, Argument, Right(ghi))
+    *
+    * scala> source.read(2)
+    * res2: ConfigSourceEntry[Int] = ConfigSourceEntry(2, Argument, Left(MissingKey(2, Argument)))
+    * }}}
+    */
+  def fromEntries[Key](keyType: ConfigKeyType[Key])(entries: (Key, String)*): ConfigSource[Key] =
+    ConfigSource.fromMap(keyType)(entries.toMap)
+
+  /**
+    * Creates a new [[ConfigSource]] from the specified [[ConfigKeyType]]
     * and read function, reading keys of the type `Key`, and returning
     * a value wrapped in a `Try`. The source will only successfully
     * read values for keys where the function returns `Success`.

--- a/modules/spire/shared/src/main/scala/ciris/spire/package.scala
+++ b/modules/spire/shared/src/main/scala/ciris/spire/package.scala
@@ -1,0 +1,8 @@
+package ciris
+
+import ciris.spire.readers.SpireConfigReaders
+
+/**
+  * Module providing an integration with [[https://github.com/non/spire spire]].
+  */
+package object spire extends SpireConfigReaders

--- a/modules/spire/shared/src/main/scala/ciris/spire/readers/SpireConfigReaders.scala
+++ b/modules/spire/shared/src/main/scala/ciris/spire/readers/SpireConfigReaders.scala
@@ -1,0 +1,76 @@
+package ciris.spire.readers
+
+import ciris.ConfigReader
+import spire.math._
+
+import scala.util.{Success, Try}
+
+trait SpireConfigReaders {
+  implicit val algebraicConfigReader: ConfigReader[Algebraic] =
+    ConfigReader.catchNonFatal("Algebraic")(Algebraic.apply)
+
+  implicit val intervalRationalConfigReader: ConfigReader[Interval[Rational]] =
+    ConfigReader.catchNonFatal("Interval[Rational]")(Interval.apply)
+
+  implicit val naturalConfigReader: ConfigReader[Natural] =
+    ConfigReader.fromTryOption("Natural") { value =>
+      if (value.forall(_.isDigit))
+        Try(Some(Natural(value)))
+      else
+        Success(None)
+    }
+
+  implicit val numberConfigReader: ConfigReader[Number] =
+    ConfigReader.catchNonFatal("Number")(Number.apply)
+
+  implicit val polynomialRationalConfigReader: ConfigReader[Polynomial[Rational]] =
+    ConfigReader.catchNonFatal("Polynomial[Rational]")(Polynomial.apply)
+
+  implicit val rationalConfigReader: ConfigReader[Rational] =
+    ConfigReader.catchNonFatal("Rational")(Rational.apply)
+
+  implicit val realConfigReader: ConfigReader[Real] =
+    ConfigReader.catchNonFatal("Real")(Real.apply)
+
+  implicit def safeLongConfigReader(
+    implicit reader: ConfigReader[BigInt]
+  ): ConfigReader[SafeLong] =
+    reader.map(SafeLong.apply)
+
+  implicit def trileanConfigReader(
+    implicit reader: ConfigReader[Option[Boolean]]
+  ): ConfigReader[Trilean] =
+    reader.map(Trilean.apply)
+
+  implicit def ubyteConfigReader(
+    implicit reader: ConfigReader[Int]
+  ): ConfigReader[UByte] =
+    reader.collect("UByte") {
+      case int if UByte.MinValue.toInt <= int && int <= UByte.MaxValue.toInt =>
+        UByte(int)
+    }
+
+  implicit def uintConfigReader(
+    implicit reader: ConfigReader[Long]
+  ): ConfigReader[UInt] =
+    reader.collect("UInt") {
+      case long if UInt.MinValue.toLong <= long && long <= UInt.MaxValue.toLong =>
+        UInt(long)
+    }
+
+  implicit def ulongConfigReader(
+    implicit reader: ConfigReader[BigInt]
+  ): ConfigReader[ULong] =
+    reader.collect("ULong") {
+      case bigInt if ULong.MinValue.toBigInt <= bigInt && bigInt <= ULong.MaxValue.toBigInt =>
+        ULong.fromBigInt(bigInt)
+    }
+
+  implicit def ushortConfigReader(
+    implicit reader: ConfigReader[Int]
+  ): ConfigReader[UShort] =
+    reader.collect("UShort") {
+      case int if UShort.MinValue.toInt <= int && int <= UShort.MaxValue.toInt =>
+        UShort(int)
+    }
+}

--- a/tests/shared/src/test/scala/ciris/ConfigReaderSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigReaderSpec.scala
@@ -1,5 +1,7 @@
 package ciris
 
+import scala.util.Try
+
 final class ConfigReaderSpec extends PropertySpec {
   "ConfigReader" when {
     "using mapBoth" should {
@@ -13,6 +15,75 @@ final class ConfigReaderSpec extends PropertySpec {
         forAll { value: String =>
           reader.read(existingEntry(value)) shouldBe Right(value + "123")
         }
+      }
+    }
+
+    "using fromTryOption" should {
+      val reader = ConfigReader.fromTryOption("typeName")(value => Try {
+        value match {
+          case "some" => Some("ok")
+          case "none" => None
+          case _ => throw new Error
+        }
+      })
+
+      "succeed for Success[Some]" in {
+        reader.read(existingEntry("some")) shouldBe a[Right[_, _]]
+      }
+
+      "fail for Success[None]" in {
+        reader.read(existingEntry("none")) shouldBe a[Left[_, _]]
+      }
+
+      "fail for Failure" in {
+        reader.read(existingEntry("error")) shouldBe a[Left[_, _]]
+      }
+    }
+
+    "using mapTry" should {
+      val reader = ConfigReader.identity.mapTry("typeName")(value => Try {
+        value match {
+          case "ok" => "ok"
+          case _ => throw new Error
+        }
+      })
+
+      "succeed for Success" in {
+        reader.read(existingEntry("ok")) shouldBe a[Right[_, _]]
+      }
+
+      "fail for Failure" in {
+        reader.read(existingEntry("error")) shouldBe a[Left[_, _]]
+      }
+    }
+
+    "using mapCatchNonFatal" should {
+      val reader = ConfigReader.identity.mapCatchNonFatal("typeName") {
+        case "ok" => "ok"
+        case _ => throw new Error
+      }
+
+      "succeed for Success" in {
+        reader.read(existingEntry("ok")) shouldBe a[Right[_, _]]
+      }
+
+      "fail for Failure" in {
+        reader.read(existingEntry("error")) shouldBe a[Left[_, _]]
+      }
+    }
+
+    "using collect" should {
+      val reader = ConfigReader.identity.collect("typeName") {
+        case value if value == "ok" =>
+          "ok"
+      }
+
+      "succeed if the partial function is defined" in {
+        reader.read(existingEntry("ok")) shouldBe a [Right[_, _]]
+      }
+
+      "fail if the partial function is undefined" in {
+        reader.read(existingEntry("error")) shouldBe a [Left[_, _]]
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/spire/readers/SpireConfigReadersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/spire/readers/SpireConfigReadersSpec.scala
@@ -1,0 +1,169 @@
+package ciris.spire.readers
+
+import _root_.spire.math._
+import ciris._
+import ciris.spire._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+
+final class SpireConfigReadersSpec extends PropertySpec {
+  "SpireConfigReaders" when {
+    "reading Algebraic" should {
+      "successfully read all BigDecimal strings" in {
+        forAll { bigDecimal: BigDecimal =>
+          ConfigReader[Algebraic].read(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading Interval[Rational]" should {
+      val reader = ConfigReader[Interval[Rational]]
+      def shouldSucceed(value: String) =
+        reader.read(existingEntry(value)) shouldBe a[Right[_, _]]
+
+      "successfully read Interval.all" in {
+        shouldSucceed("(-∞, ∞)")
+      }
+
+      "successfully read valid intervals" in {
+        forAll { (a: BigInt, b: Option[BigInt]) =>
+          whenever(!b.exists(_ == 0)) {
+            val s = s"$a${b.map(b => s"/$b").getOrElse("")}"
+
+            shouldSucceed(s"(-∞, $s)")
+            shouldSucceed(s"(-∞, $s]")
+            shouldSucceed(s"($s, ∞)")
+            shouldSucceed(s"[$s, ∞)")
+            shouldSucceed(s"[$s, $s]")
+            shouldSucceed(s"($s, $s)")
+            shouldSucceed(s"[$s, $s)")
+            shouldSucceed(s"($s, $s]")
+          }
+        }
+      }
+    }
+
+    "reading Natural" should {
+      "successfully read digit-only strings" in {
+        val gen = for {
+          size <- Gen.chooseNum(1, 100)
+          string <- Gen.listOfN(size, Gen.chooseNum(0, 9))
+        } yield string.mkString
+
+        forAll(gen) { digitString =>
+          ConfigReader[Natural].read(existingEntry(digitString)) shouldBe a[Right[_, _]]
+        }
+      }
+
+      "fail to read non digit-only strings" in {
+        forAll { string: String =>
+          whenever(string.exists(c => !c.isDigit)) {
+            ConfigReader[Natural].read(existingEntry(string)) shouldBe a[Left[_, _]]
+          }
+        }
+      }
+    }
+
+    "reading Number" should {
+      "successfully read all BigDecimal strings" in {
+        forAll { bigDecimal: BigDecimal =>
+          ConfigReader[Number].read(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading Polynomial[Rational]" should {
+      "successfully read an example polynomial" in {
+        ConfigReader[Polynomial[Rational]]
+          .read(existingEntry("1/5x + 1/3x^2")) shouldBe a[Right[_, _]]
+      }
+    }
+
+    "reading Rational" should {
+      "successfully read rationals on the form d/n" in {
+        val gen = for {
+          n <- arbitrary[BigInt]
+          d <- Gen.option(arbitrary[BigInt])
+          if !d.exists(_ == 0)
+        } yield s"$n${d.map(d => "/" + d).getOrElse("")}"
+
+        forAll(gen) { rationalString =>
+          ConfigReader[Rational].read(existingEntry(rationalString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading Real" should {
+      "successfully read all BigDecimal strings" in {
+        forAll { bigDecimal: BigDecimal =>
+          ConfigReader[Real].read(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading SafeLong" should {
+      "successfully read all BigInt strings" in {
+        forAll { bigInt: BigInt =>
+          ConfigReader[SafeLong].read(existingEntry(bigInt.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading Trilean" should {
+      "successfully read missing value as unknown" in {
+        ConfigReader[Trilean].read(nonExistingEntry) shouldBe Right(Trilean.Unknown)
+      }
+
+      "successfully read boolean values" in {
+        val gen = Gen.oneOf(mixedCase("true"), mixedCase("false"))
+        forAll(gen) { booleanString =>
+          ConfigReader[Trilean].read(existingEntry(booleanString)) shouldBe Right {
+            if (booleanString.toBoolean) Trilean.True else Trilean.False
+          }
+        }
+      }
+    }
+
+    "reading UByte" should {
+      "be able to read all representable values" in {
+        val gen = Gen.chooseNum(UByte.MinValue.toInt, UByte.MaxValue.toInt)
+        forAll(gen) { value =>
+          ConfigReader[UByte].read(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading UInt" should {
+      "be able to read all representable values" in {
+        val gen = Gen.chooseNum(UInt.MinValue.toLong, UInt.MaxValue.toLong)
+        forAll(gen) { value =>
+          ConfigReader[UInt].read(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading ULong" should {
+      "be able to read all representable values" in {
+        val gen = for {
+          first <- Gen.chooseNum(0L, Long.MaxValue)
+          second <- Gen.chooseNum(0L, Long.MaxValue)
+          zeroOrOne <- Gen.choose(0L, 1L)
+        } yield
+          BigInt(first) + BigInt(second) + zeroOrOne // ULong.MaxValue is 2 * Long.MaxValue + 1
+
+        forAll(gen) { value =>
+          ConfigReader[ULong].read(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+
+    "reading UShort" should {
+      "be able to read all representable values" in {
+        val gen = Gen.chooseNum(UShort.MinValue.toInt, UShort.MaxValue.toInt)
+        forAll(gen) { value =>
+          ConfigReader[UShort].read(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a `ciris-spire` module with support for [spire](https://github.com/non/spire) number types: `Algebraic`, `Interval[Rational]`, `Natural`, `Number`, `Polynomial[Rational]`, `Rational`, `Real`, `SafeLong`, `Trilean`, `UByte`, `UInt`, `ULong`, and `UShort`.

Bonus:
- Add `ConfigReader#collect`, `mapTry`, `mapCatchNonFatal`, `fromTryOption`.
- Add `ConfigSource#fromEntries`.
- Update Ammonite to 1.0.2.