### PR TITLE
Add ConfigValue#orElse

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigError.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigError.scala
@@ -128,7 +128,7 @@ object ConfigError {
     *
     * @param errors two or more errors to combine
     */
-  private sealed class Combined(val errors: Vector[ConfigError]) extends ConfigError {
+  private sealed case class Combined(errors: Vector[ConfigError]) extends ConfigError {
     override def message: String = errors.map(_.message).mkString(", ")
     override def toString: String = s"Combined($errors)"
   }
@@ -174,7 +174,7 @@ object ConfigError {
     * @param keyType the type of keys the configuration source reads
     * @tparam Key the type of the key
     */
-  private sealed class MissingKey[Key](key: Key, keyType: ConfigKeyType[Key]) extends ConfigError {
+  private sealed case class MissingKey[Key](key: Key, keyType: ConfigKeyType[Key]) extends ConfigError {
     override def message: String = s"Missing ${keyType.name} [$key]"
     override def toString: String = s"MissingKey($key, $keyType)"
   }
@@ -219,7 +219,7 @@ object ConfigError {
     * @param cause the reason why there was an exception while reading
     * @tparam Key the type of the key
     */
-  private sealed class ReadException[Key](key: Key, keyType: ConfigKeyType[Key], cause: Throwable) extends ConfigError {
+  private sealed case class ReadException[Key](key: Key, keyType: ConfigKeyType[Key], cause: Throwable) extends ConfigError {
     override def message: String = s"Exception while reading ${keyType.name} [$key]: $cause"
     override def toString: String = s"ReadException($key, $keyType, $cause)"
   }
@@ -270,7 +270,7 @@ object ConfigError {
     * @tparam Value the type of the value
     * @tparam Cause the type of the cause
     */
-  private sealed class WrongType[Key, Value, Cause](
+  private sealed case class WrongType[Key, Value, Cause](
     key: Key,
     value: Value,
     typeName: String,

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -63,12 +63,12 @@ sealed abstract class ConfigValue[Value] {
     * }}}
     */
   final def orElse[A >: Value](that: => ConfigValue[A]): ConfigValue[A] =
-    ConfigValue(value.fold(error => {
+    ConfigValue(value.fold(thisError => {
       that.value.fold(
-        nextError => Left(error combine nextError),
-        nextValue => Right(nextValue)
+        thatError => Left(thisError combine thatError),
+        thatValue => Right(thatValue)
       )
-    }, value => Right(value)))
+    }, thisValue => Right(thisValue)))
 
   private[ciris] def append[A](next: ConfigValue[A]): ConfigValue2[Value, A] = {
     (value, next.value) match {
@@ -124,8 +124,9 @@ object ConfigValue {
   def apply[Key, Value](key: Key)(
     source: ConfigSource[Key],
     reader: ConfigReader[Value]
-  ): ConfigValue[Value] =
+  ): ConfigValue[Value] = {
     ConfigValue(reader.read[Key](source.read(key)))
+  }
 
   /**
     * Partial type application of [[ConfigValue]] by first fixing

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -45,6 +45,29 @@ sealed abstract class ConfigValue[Value] {
 object ConfigValue {
 
   /**
+    * Creates a new [[ConfigValue]] from the specified value, which is
+    * the result of having read some configuration value from a source
+    * and converted it to type `Value`.
+    *
+    * @param value the read configuration value or a [[ConfigError]]
+    * @tparam Value the type of the value
+    * @return a new [[ConfigValue]] with the specified value
+    * @example {{{
+    * scala> ConfigValue[Int](Left(ConfigError("error")))
+    * res0: ConfigValue[Int] = ConfigValue(Left(ConfigError(error)))
+    *
+    * scala> ConfigValue(Right(123))
+    * res1: ConfigValue[Int] = ConfigValue(Right(123))
+    * }}}
+    */
+  def apply[Value](value: Either[ConfigError, Value]): ConfigValue[Value] = {
+    val _value = value
+    new ConfigValue[Value] {
+      override val value: Either[ConfigError, Value] = _value
+    }
+  }
+
+  /**
     * Creates a new [[ConfigValue]] by reading the specified key from
     * the configuration source, converting the value to type `Value`
     * using the specified [[ConfigReader]].
@@ -63,12 +86,8 @@ object ConfigValue {
   def apply[Key, Value](key: Key)(
     source: ConfigSource[Key],
     reader: ConfigReader[Value]
-  ): ConfigValue[Value] = {
-    new ConfigValue[Value] {
-      override def value: Either[ConfigError, Value] =
-        reader.read[Key](source.read(key))
-    }
-  }
+  ): ConfigValue[Value] =
+    ConfigValue(reader.read[Key](source.read(key)))
 
   /**
     * Partial type application of [[ConfigValue]] by first fixing

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -8,12 +8,15 @@ package ciris
   *
   * To create a [[ConfigValue]], you typically use methods like [[env]],
   * [[prop]], or [[read]], but if you need to write a similar method for
-  * a custom configuration source, use the [[ConfigValue#apply]] method,
-  * requiring a [[ConfigSource]] and [[ConfigReader]].
+  * a custom configuration source, you can use the functions provided in
+  * the companion object.
   *
   * {{{
   * scala> ConfigValue("key")(ConfigSource.Properties, ConfigReader[String])
   * res0: ConfigValue[String] = ConfigValue(Left(MissingKey(key, Property)))
+  *
+  * scala> ConfigValue(Right(123))
+  * res1: ConfigValue[Int] = ConfigValue(Right(123))
   * }}}
   *
   * @tparam Value the type of the value
@@ -31,6 +34,41 @@ sealed abstract class ConfigValue[Value] {
 
   override def toString: String =
     s"ConfigValue($value)"
+
+  /**
+    * If `this` configuration value was read successfully, uses `this`
+    * value, otherwise uses the configuration value of `that`. If an
+    * error occurred for both configuration values, their errors
+    * will be accumulated.
+    *
+    * Note that the provided [[ConfigValue]] will only be evaluated
+    * if `this` configuration value is an error. This allows you to
+    * chain configuration values like in the following example.
+    *
+    * @param that the [[ConfigValue]] to use if `this` value is an error
+    * @tparam A the type of `that` [[ConfigValue]] to use
+    * @return a new [[ConfigValue]]
+    * @example {{{
+    * scala> val error =
+    *      |  ConfigValue[Int](Left(ConfigError("error1"))).
+    *      |    orElse(ConfigValue(Left(ConfigError("error2"))))
+    * error: ConfigValue[Int] = ConfigValue(Left(Combined(Vector(ConfigError(error1), ConfigError(error2)))))
+    *
+    * scala> error.value.left.map(_.message).toString
+    * res0: String = Left(error1, error2)
+    *
+    * scala> ConfigValue[Int](Left(ConfigError("error1"))).
+    *      |   orElse(ConfigValue(Right(123)))
+    * res1: ConfigValue[Int] = ConfigValue(Right(123))
+    * }}}
+    */
+  final def orElse[A >: Value](that: => ConfigValue[A]): ConfigValue[A] =
+    ConfigValue(value.fold(error => {
+      that.value.fold(
+        nextError => Left(error combine nextError),
+        nextValue => Right(nextValue)
+      )
+    }, value => Right(value)))
 
   private[ciris] def append[A](next: ConfigValue[A]): ConfigValue2[Value, A] = {
     (value, next.value) match {

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -7,5 +7,32 @@ final class ConfigValueSpec extends PropertySpec {
         readConfigValue[String]("value").toString shouldBe "ConfigValue(Right(value))"
       }
     }
+
+    "using orElse" should {
+      "use the first value even if the second is available" in {
+        val result = ConfigValue(Right(123)) orElse ConfigValue(Right(456))
+        result.value shouldBe Right(123)
+      }
+
+      "not evaluate the second value if the first is available" in {
+        ConfigValue(Right(123)) orElse fail("orElse evaluated second value")
+      }
+
+      "use the first value if the second one contains an error" in {
+        val result = ConfigValue(Right(123)) orElse ConfigValue(Left(ConfigError("error")))
+        result.value shouldBe Right(123)
+      }
+
+      "use the second value if first contains an error" in {
+        val result = ConfigValue(Left(ConfigError("error"))) orElse ConfigValue(Right(456))
+        result.value shouldBe Right(456)
+      }
+
+      "combine errors if both contain errors" in {
+        val (error1, error2) = (ConfigError("error1"), ConfigError("error2"))
+        val result = ConfigValue(Left(error1)) orElse ConfigValue(Left(error2))
+        result.value shouldBe Left(ConfigError.combined(error1, error2))
+      }
+    }
   }
 }


### PR DESCRIPTION
Add `ConfigValue#orElse` for chaining `ConfigValue`s, allowing to specify alternative values in case the previous ones are not available.

```scala
import ciris._

val awsSecretAccessKey =
  env[String]("AWS_SECRET_ACCESS_KEY").
    orElse(env[String]("AWS_SECRET_KEY"))
// awsSecretAccessKey: ConfigValue[String] = ConfigValue(Left(Combined(Vector(MissingKey(AWS_SECRET_ACCESS_KEY, Environment), MissingKey(AWS_SECRET_KEY, Environment)))))

awsSecretAccessKey.value.left.map(_.message)
// res0: Either[String,String] = Left(Missing environment variable [AWS_SECRET_ACCESS_KEY], Missing environment variable [AWS_SECRET_KEY])
```