### PR TITLE
Add ConfigValue#refine and mapRefine syntax

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -36,6 +36,31 @@ sealed abstract class ConfigValue[Value] {
     s"ConfigValue($value)"
 
   /**
+    * Returns a new [[ConfigValue]] with the value transformed using
+    * the provided function. If there is no value, due to an error,
+    * returns a [[ConfigValue]] with the error instead.
+    *
+    * @param f a function with which to transform the value
+    * @tparam A the type of value the provided function returns
+    * @return a new [[ConfigValue]] with the transformed value
+    */
+  final def map[A](f: Value => A): ConfigValue[A] =
+    ConfigValue(value.right.map(f))
+
+  /**
+    * Returns a new [[ConfigValue]] from the existing value of this
+    * [[ConfigValue]] and by applying the function `f`. If there is
+    * no value, due to an error, returns a [[ConfigValue]] with the
+    * error instead.
+    *
+    * @param f a function from which to create a new [[ConfigValue]]
+    * @tparam A the type of value for the new [[ConfigValue]]
+    * @return a new [[ConfigValue]] from the provided function
+    */
+  final def flatMap[A](f: Value => Either[ConfigError, A]): ConfigValue[A] =
+    ConfigValue(value.right.flatMap(f))
+
+  /**
     * If `this` configuration value was read successfully, uses `this`
     * value, otherwise uses the configuration value of `that`. If an
     * error occurred for both configuration values, their errors
@@ -72,9 +97,9 @@ sealed abstract class ConfigValue[Value] {
 
   private[ciris] def append[A](next: ConfigValue[A]): ConfigValue2[Value, A] = {
     (value, next.value) match {
-      case (Right(a), Right(b)) => new ConfigValue2(Right((a, b)))
-      case (Left(error1), Right(_)) => new ConfigValue2(Left(ConfigErrors(error1)))
-      case (Right(_), Left(error2)) => new ConfigValue2(Left(ConfigErrors(error2)))
+      case (Right(a), Right(b))         => new ConfigValue2(Right((a, b)))
+      case (Left(error1), Right(_))     => new ConfigValue2(Left(ConfigErrors(error1)))
+      case (Right(_), Left(error2))     => new ConfigValue2(Left(ConfigErrors(error2)))
       case (Left(error1), Left(error2)) => new ConfigValue2(Left(error1 append error2))
     }
   }

--- a/modules/refined/shared/src/main/scala/ciris/refined/syntax.scala
+++ b/modules/refined/shared/src/main/scala/ciris/refined/syntax.scala
@@ -1,0 +1,86 @@
+package ciris.refined
+
+import ciris.{ConfigError, ConfigValue}
+import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.refineV
+
+object syntax {
+  implicit def refinedConfigValueSyntax[T](
+    config: ConfigValue[T]
+  ): RefinedConfigValueSyntax[T] = {
+    new RefinedConfigValueSyntax[T](config)
+  }
+
+  final class RefinedConfigValueSyntax[T](val config: ConfigValue[T]) extends AnyVal {
+
+    /**
+      * Attempts to refine the [[ConfigValue]] by checking whether the
+      * value conforms to the predicate `P`. If the value conforms to
+      * the predicate, returns a new [[ConfigValue]] with the refined
+      * value; otherwise, returns a new [[ConfigValue]] with an error
+      * detailing why the value does not conform to the predicate.
+      *
+      * @param validate the implicit validate instance for the predicate
+      * @tparam P the type of the predicate, must be specified
+      * @return a new [[ConfigValue]] with the result of the refinement
+      * @example {{{
+      * scala> import ciris._, ciris.refined.syntax._, eu.timepit.refined.api.Refined, eu.timepit.refined.collection.NonEmpty
+      * import ciris._
+      * import ciris.refined.syntax._
+      * import eu.timepit.refined.api.Refined
+      * import eu.timepit.refined.collection.NonEmpty
+      *
+      * scala> val secret = ConfigValue(Right("secret")).refine[NonEmpty]
+      * secret: ConfigValue[Refined[String,NonEmpty]] = ConfigValue(Right(secret))
+      * }}}
+      */
+    def refine[P](implicit validate: Validate[T, P]): ConfigValue[Refined[T, P]] =
+      config.flatMap { t =>
+        refineV[P](t).fold(
+          error => Left(ConfigError(s"Unable to refine value [$t]: $error")),
+          refined => Right(refined)
+        )
+      }
+
+    /**
+      * Applies a function to the [[ConfigValue]] and attempts to refine
+      * the returned value, by checking whether the value conforms to the
+      * specified predicate `P`.
+      *
+      * For this to work, we need to partially apply type parameters, so
+      * this function returns an intermediate [[MapRefinePartiallyApplied]]
+      * class for that purpose. However, you can simply use this function
+      * like in the following example.
+      *
+      * @tparam P the type of the predicate, must be specified
+      * @return a new [[ConfigValue]] with the result of the refinement
+      * @example {{{
+      * scala> import ciris._, ciris.refined.syntax._, eu.timepit.refined.api.Refined, eu.timepit.refined.string.Uri
+      * import ciris._
+      * import ciris.refined.syntax._
+      * import eu.timepit.refined.api.Refined
+      * import eu.timepit.refined.string.Uri
+      *
+      * scala> val host = ConfigValue(Right("google.com"))
+      * host: ConfigValue[String] = ConfigValue(Right(google.com))
+      *
+      * scala> val api = host.mapRefine[Uri](_ + "/api")
+      * api: ConfigValue[Refined[String,Uri]] = ConfigValue(Right(google.com/api))
+      * }}}
+      */
+    def mapRefine[P]: MapRefinePartiallyApplied[T, P] =
+      new MapRefinePartiallyApplied[T, P](config)
+  }
+
+  final class MapRefinePartiallyApplied[T, P](val config: ConfigValue[T]) extends AnyVal {
+    def apply[S](f: T => S)(implicit validate: Validate[S, P]): ConfigValue[Refined[S, P]] =
+      config.flatMap { t =>
+        val s = f(t)
+        refineV[P](s).fold(
+          error =>
+            Left(ConfigError(s"Converted value [$t] to [$s] but was unable to refine: $error")),
+          refined => Right(refined)
+        )
+      }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -34,5 +34,27 @@ final class ConfigValueSpec extends PropertySpec {
         result.value shouldBe Left(ConfigError.combined(error1, error2))
       }
     }
+
+    "using map" should {
+      "successfully map available values" in {
+        ConfigValue(Right(123)).map(_ * 2).value shouldBe Right(246)
+      }
+
+      "return an error when the value is unavailable" in {
+        ConfigValue[Int](Left(ConfigError("123"))).map(_ * 2).value shouldBe a[Left[_, _]]
+      }
+    }
+
+    "using flatMap" should {
+      "successfully flatMap available values" in {
+        ConfigValue(Right(123)).flatMap(int => Right(int * 2)).value shouldBe Right(246)
+      }
+
+      "return an error when the value in unavailable" in {
+        ConfigValue[Int](Left(ConfigError("123")))
+          .flatMap(int => Right(int * 2))
+          .value shouldBe a[Left[_, _]]
+      }
+    }
   }
 }

--- a/tests/shared/src/test/scala/ciris/refined/RefinedConfigValueSyntaxSpec.scala
+++ b/tests/shared/src/test/scala/ciris/refined/RefinedConfigValueSyntaxSpec.scala
@@ -1,0 +1,50 @@
+package ciris.refined
+
+import ciris.refined.syntax._
+import ciris._
+import eu.timepit.refined.numeric.Positive
+import org.scalacheck.{Gen, Shrink}
+
+final class RefinedConfigValueSyntaxSpec extends PropertySpec {
+  implicit def noShrink[T] = Shrink[T](_ => Stream.empty)
+
+  "RefinedConfigValueSyntax" when {
+    "using refine" should {
+      "successfully refine values conforming to predicate" in {
+        forAll(Gen.chooseNum(1, Int.MaxValue)) { n: Int =>
+          ConfigValue(Right(n)).refine[Positive].value shouldBe a[Right[_, _]]
+        }
+      }
+
+      "return an error when refining values not confirming to predicate" in {
+        forAll(Gen.chooseNum(Int.MinValue, 0)) { n: Int =>
+          ConfigValue(Right(n)).refine[Positive].value shouldBe a[Left[_, _]]
+        }
+      }
+
+      "return an error when refining unavailable values" in {
+        ConfigValue[Int](Left(ConfigError("error"))).refine[Positive].value shouldBe a[Left[_, _]]
+      }
+    }
+
+    "using mapRefine" should {
+      "successfully refine value conforming to predicate" in {
+        forAll(Gen.chooseNum(1, Int.MaxValue)) { n: Int =>
+          ConfigValue(Right(n)).mapRefine[Positive](identity).value shouldBe a[Right[_, _]]
+        }
+      }
+
+      "return an error when refining value not confirming to predicate" in {
+        forAll(Gen.chooseNum(Int.MinValue, 0)) { n: Int =>
+          ConfigValue(Right(n)).mapRefine[Positive](identity).value shouldBe a[Left[_, _]]
+        }
+      }
+
+      "return an error when refining unavailable values" in {
+        ConfigValue[Int](Left(ConfigError("error")))
+          .mapRefine[Positive](identity)
+          .value shouldBe a[Left[_, _]]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allows to refine configuration values with `refine` and `mapRefine`, like in the following examples.

```scala
scala> import ciris._, ciris.refined.syntax._, eu.timepit.refined.api.Refined, eu.timepit.refined.collection.NonEmpty
import ciris._
import ciris.refined.syntax._
import eu.timepit.refined.api.Refined
import eu.timepit.refined.collection.NonEmpty

scala> val secret = ConfigValue(Right("secret")).refine[NonEmpty]
secret: ConfigValue[Refined[String,NonEmpty]] = ConfigValue(Right(secret))
```

```scala
scala> import ciris._, ciris.refined.syntax._, eu.timepit.refined.api.Refined, eu.timepit.refined.string.Uri
import ciris._
import ciris.refined.syntax._
import eu.timepit.refined.api.Refined
import eu.timepit.refined.string.Uri

scala> val host = ConfigValue(Right("google.com"))
host: ConfigValue[String] = ConfigValue(Right(google.com))

scala> val api = host.mapRefine[Uri](_ + "/api")
api: ConfigValue[Refined[String,Uri]] = ConfigValue(Right(google.com/api))
```