### PR TITLE
Fix ConfigException#toString

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigException.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigException.scala
@@ -3,32 +3,22 @@ package ciris
 /**
   * A `Throwable` representation of [[ConfigErrors]]. Useful in cases
   * where it's desirable to have failed configuration loading halt
-  * program execution - typically during application startup.<br>
-  * <br>
-  * There's a quick way to convert [[ConfigErrors]] to an exception.
-  * {{{
-  * scala> ConfigErrors(ConfigError("error1")).toException
-  * res0: ConfigException = ConfigException(ConfigError(error1))
-  * }}}
+  * program execution - typically during application startup.
   *
   * @param errors the underlying [[ConfigErrors]] of the exception
   */
 final class ConfigException private (val errors: ConfigErrors)
     extends Throwable({
-      val errorCount =
-        if (errors.size == 1) "error"
-        else s"[${errors.size}] errors"
-
       val errorMessages =
         errors.toVector
           .map(error => s"  - ${error.message}.")
           .mkString("\n", "\n", "\n")
 
-      s"configuration loading failed with the following $errorCount.\n$errorMessages"
+      s"configuration loading failed with the following errors.\n$errorMessages"
     }) {
 
   override def toString: String =
-    s"ConfigException(${errors.toVector.mkString(", ")})"
+    s"ciris.ConfigException: $getMessage"
 }
 
 object ConfigException {
@@ -38,13 +28,6 @@ object ConfigException {
     *
     * @param errors the [[ConfigErrors]] from which to create the exception
     * @return a new [[ConfigException]]
-    * @example {{{
-    * scala> ConfigException(ConfigError("error1") append ConfigError("error2"))
-    * res0: ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
-    *
-    * scala> (ConfigError("error1") append ConfigError("error2")).toException
-    * res1: ConfigException = ConfigException(ConfigError(error1), ConfigError(error2))
-    * }}}
     */
   def apply(errors: ConfigErrors): ConfigException =
     new ConfigException(errors)

--- a/tests/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
@@ -9,7 +9,7 @@ final class ConfigExceptionSpec extends PropertySpec {
             .append(ConfigError.readException("key", ConfigKeyType.Property, new Error("error")))
             .toException
 
-        configException.toString shouldBe "ConfigException(MissingKey(key, Environment), ReadException(key, Property, java.lang.Error: error))"
+        configException.toString shouldBe s"ciris.ConfigException: ${configException.getMessage}"
       }
     }
 
@@ -21,7 +21,7 @@ final class ConfigExceptionSpec extends PropertySpec {
 
           configException.getMessage.trim shouldBe
             """
-              |configuration loading failed with the following error.
+              |configuration loading failed with the following errors.
               |
               |  - Missing environment variable [key].
             """.stripMargin.trim
@@ -37,7 +37,7 @@ final class ConfigExceptionSpec extends PropertySpec {
 
           configException.getMessage.trim shouldBe
             """
-              |configuration loading failed with the following [2] errors.
+              |configuration loading failed with the following errors.
               |
               |  - Missing environment variable [key].
               |  - Exception while reading system property [key]: java.lang.Error: error.


### PR DESCRIPTION
Ensures that the exception message is included in `toString`, and therefore also in stack traces.
```
scala> loadConfig(env[Int]("A"), prop[Int]("B"))(_ + _).orThrow()
ciris.ConfigException: configuration loading failed with the following errors.

  - Environment variable [A] with value [x] cannot be converted to type [Int]: java.lang.NumberFormatException: For input string: "x".
  - Missing system property [B].

  at ciris.ConfigException$.apply(ConfigException.scala:46)
  at ciris.ConfigErrors$.toException$extension(ConfigErrors.scala:109)
  at ciris.syntax$EitherConfigErrorsSyntax$.$anonfun$orThrow$1(syntax.scala:22)
  at ciris.syntax$EitherConfigErrorsSyntax$.$anonfun$orThrow$1$adapted(syntax.scala:22)
  at scala.util.Either.fold(Either.scala:189)
  at ciris.syntax$EitherConfigErrorsSyntax$.orThrow$extension(syntax.scala:23)
  ... 36 elided
```