### PR TITLE
Add support for reading files

### DIFF
--- a/modules/core/js/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/js/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package ciris
+
+private[ciris] trait CirisPlatformSpecific

--- a/modules/core/js/src/main/scala/ciris/ConfigKeyTypePlatformSpecific.scala
+++ b/modules/core/js/src/main/scala/ciris/ConfigKeyTypePlatformSpecific.scala
@@ -1,0 +1,3 @@
+package ciris
+
+private[ciris] trait ConfigKeyTypePlatformSpecific

--- a/modules/core/js/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/js/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -1,0 +1,3 @@
+package ciris
+
+private[ciris] trait ConfigSourcePlatformSpecific

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -9,11 +9,11 @@ private[ciris] trait CirisPlatformSpecific {
     * Reads the contents of the specified `file` with `charset`,
     * applies the `modifyFileContents` function on the contents,
     * and attempts to convert the modified file contents to type
-    * [[Value]]. The result is wrapped in a [[ConfigValue]].
+    * `Value`. The result is wrapped in a [[ConfigValue]].
     *
     * @param file the file of which to read the contents
     * @param modifyFileContents the function to apply on the file contents
-    *                           before trying to convert to type [[Value]];
+    *                           before trying to convert to type `Value`;
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
     *                defaults to [[Charset.defaultCharset]]
@@ -40,12 +40,12 @@ private[ciris] trait CirisPlatformSpecific {
   /**
     * Reads the contents of the specified file `name` with `charset`,
     * applies the `modifyFileContents` function on the contents, and
-    * attempts to convert the modified file contents to type [[Value]].
+    * attempts to convert the modified file contents to type `Value`.
     * The result is wrapped in a [[ConfigValue]].
     *
     * @param name the name of the file of which to read the contents
     * @param modifyFileContents the function to apply on the file contents
-    *                           before trying to convert to type [[Value]];
+    *                           before trying to convert to type `Value`;
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
     *                defaults to [[Charset.defaultCharset]]

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -1,0 +1,67 @@
+package ciris
+
+import java.io.File
+import java.nio.charset.Charset
+
+private[ciris] trait CirisPlatformSpecific {
+
+  /**
+    * Reads the contents of the specified `file` with `charset`,
+    * applies the `modifyFileContents` function on the contents,
+    * and attempts to convert the modified file contents to type
+    * [[Value]]. The result is wrapped in a [[ConfigValue]].
+    *
+    * @param file the file of which to read the contents
+    * @param modifyFileContents the function to apply on the file contents
+    *                           before trying to convert to type [[Value]];
+    *                           defaults to not modify the file contents
+    * @param charset the charset of the file to read;
+    *                defaults to [[Charset.defaultCharset]]
+    * @tparam Value the type to convert the value to
+    * @return a [[ConfigValue]] with the result
+    * @see [[fileWithName]]
+    * @example {{{
+    * scala> file[Double](new java.io.File("/number.txt"))
+    * res0: ConfigValue[Double] = ConfigValue(Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
+    * }}}
+    */
+  def file[Value: ConfigReader](
+    file: File,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  ): ConfigValue[Value] = {
+    ConfigValue((file, charset))(
+      ConfigSource.File,
+      ConfigReader[Value]
+        .mapEntryValue(modifyFileContents)
+    )
+  }
+
+  /**
+    * Reads the contents of the specified file `name` with `charset`,
+    * applies the `modifyFileContents` function on the contents, and
+    * attempts to convert the modified file contents to type [[Value]].
+    * The result is wrapped in a [[ConfigValue]].
+    *
+    * @param name the name of the file of which to read the contents
+    * @param modifyFileContents the function to apply on the file contents
+    *                           before trying to convert to type [[Value]];
+    *                           defaults to not modify the file contents
+    * @param charset the charset of the file to read;
+    *                defaults to [[Charset.defaultCharset]]
+    * @tparam Value the type to convert the value to
+    * @return a [[ConfigValue]] with the result
+    * @see [[file]]
+    * @example {{{
+    * scala> fileWithName[Double]("/number.txt")
+    * res0: ConfigValue[Double] = ConfigValue(Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
+    * }}}
+    */
+  def fileWithName[Value: ConfigReader](
+    name: String,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  ): ConfigValue[Value] = {
+    this.file(new File(name), modifyFileContents, charset)
+  }
+}

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -16,7 +16,7 @@ private[ciris] trait CirisPlatformSpecific {
     *                           before trying to convert to type `Value`;
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
-    *                defaults to [[Charset.defaultCharset]]
+    *                defaults to `Charset.defaultCharset`
     * @tparam Value the type to convert the value to
     * @return a [[ConfigValue]] with the result
     * @see [[fileWithName]]
@@ -48,7 +48,7 @@ private[ciris] trait CirisPlatformSpecific {
     *                           before trying to convert to type `Value`;
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
-    *                defaults to [[Charset.defaultCharset]]
+    *                defaults to `Charset.defaultCharset`
     * @tparam Value the type to convert the value to
     * @return a [[ConfigValue]] with the result
     * @see [[file]]

--- a/modules/core/jvm/src/main/scala/ciris/ConfigKeyTypePlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/ConfigKeyTypePlatformSpecific.scala
@@ -1,0 +1,12 @@
+package ciris
+
+import java.io.{File => JFile}
+import java.nio.charset.Charset
+
+private[ciris] trait ConfigKeyTypePlatformSpecific {
+
+  /**
+    * [[ConfigKeyType]] for a file of type `File` with charset `Charset`.
+    */
+  val File: ConfigKeyType[(JFile, Charset)] = ConfigKeyType("file")
+}

--- a/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -1,0 +1,23 @@
+package ciris
+
+import java.io.{File => JFile}
+import java.nio.charset.Charset
+
+import scala.io.Source
+
+private[ciris] trait ConfigSourcePlatformSpecific {
+
+  /**
+    * [[ConfigSource]] reading file contents from `File` and `Charset` keys.
+    */
+  case object File extends ConfigSource[(JFile, Charset)](ConfigKeyType.File) {
+    private val delegate: ConfigSource[(JFile, Charset)] =
+      ConfigSource.catchNonFatal(keyType) {
+        case (file, charset) =>
+          Source.fromFile(file, charset.name).mkString
+      }
+
+    override def read(key: (JFile, Charset)): ConfigSourceEntry[(JFile, Charset)] =
+      delegate.read(key)
+  }
+}

--- a/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigKeyType.scala
@@ -25,7 +25,7 @@ package ciris
   */
 sealed class ConfigKeyType[Key](val name: String)
 
-object ConfigKeyType {
+object ConfigKeyType extends ConfigKeyTypePlatformSpecific {
 
   /**
     * Creates a new [[ConfigKeyType]] for the specified key name and type.

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -252,9 +252,9 @@ abstract class ConfigReader[Value] { self =>
 
   /**
     * Applies a function on the values in the [[ConfigSourceEntry]]s read by
-    * the reader, before trying to convert the value to type [[Value]]. This
-    * returns a new [[ConfigReader]] with the behavior, leaving the current
-    * [[ConfigReader]] unmodified.
+    * the reader, before trying to convert the value to type `Value`. This
+    * returns a new [[ConfigReader]] with the behavior, leaving the
+    * current [[ConfigReader]] unmodified.
     *
     * @param f the function to apply on the [[ConfigSourceEntry]] values
     * @return a new [[ConfigReader]] with the entry value transformation
@@ -263,7 +263,7 @@ abstract class ConfigReader[Value] { self =>
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> val reader = ConfigReader[Int].mapEntryValue(_.trim)
-    * reader: ConfigReader[Int] = ciris.ConfigReader$$anon$5@57c04ac9
+    * reader: ConfigReader[Int] = ciris.ConfigReader$$$$anon$$5@57c04ac9
     *
     * scala> reader.read(source.read(0))
     * res0: Either[ConfigError,Int] = Right(123)

--- a/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigReader.scala
@@ -249,6 +249,31 @@ abstract class ConfigReader[Value] { self =>
             }
           })
     }
+
+  /**
+    * Applies a function on the values in the [[ConfigSourceEntry]]s read by
+    * the reader, before trying to convert the value to type [[Value]]. This
+    * returns a new [[ConfigReader]] with the behavior, leaving the current
+    * [[ConfigReader]] unmodified.
+    *
+    * @param f the function to apply on the [[ConfigSourceEntry]] values
+    * @return a new [[ConfigReader]] with the entry value transformation
+    * @example {{{
+    * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("123 "))
+    * source: ConfigSource[Int] = ConfigSource(Argument)
+    *
+    * scala> val reader = ConfigReader[Int].mapEntryValue(_.trim)
+    * reader: ConfigReader[Int] = ciris.ConfigReader$$anon$5@57c04ac9
+    *
+    * scala> reader.read(source.read(0))
+    * res0: Either[ConfigError,Int] = Right(123)
+    * }}}
+    */
+  final def mapEntryValue(f: String => String): ConfigReader[Value] =
+    new ConfigReader[Value] {
+      override def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, Value] =
+        self.read(entry.mapValue(f))
+    }
 }
 
 object ConfigReader extends ConfigReaders {

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -48,7 +48,7 @@ abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
   def read(key: Key): ConfigSourceEntry[Key]
 }
 
-object ConfigSource {
+object ConfigSource extends ConfigSourcePlatformSpecific {
 
   /**
     * Creates a new [[ConfigSource]] from the specified [[ConfigKeyType]] and

--- a/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
@@ -41,7 +41,7 @@ sealed class ConfigSourceEntry[Key](
     * }}}
     */
   def mapValue(f: String => String): ConfigSourceEntry[Key] =
-    new ConfigSourceEntry(key, keyType, value.map(f))
+    new ConfigSourceEntry(key, keyType, value.right.map(f))
 
   override def toString: String =
     s"ConfigSourceEntry($key, $keyType, $value)"

--- a/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
@@ -25,6 +25,24 @@ sealed class ConfigSourceEntry[Key](
   val value: Either[ConfigError, String]
 ) {
 
+  /**
+    * Transforms the value read from the configuration source by applying
+    * the specified function, returning a new [[ConfigSourceEntry]] which
+    * includes the modified value.
+    *
+    * @param f the function to apply to the read configuration value
+    * @return a new [[ConfigSourceEntry]] with the transformed value
+    * @example {{{
+    * scala> val entry = ConfigSourceEntry("key", ConfigKeyType.Environment, Right("value "))
+    * entry: ConfigSourceEntry[String] = ConfigSourceEntry(key, Environment, Right(value ))
+    *
+    * scala> entry.mapValue(_.trim)
+    * res0: ciris.ConfigSourceEntry[String] = ConfigSourceEntry(key, Environment, Right(value))
+    * }}}
+    */
+  def mapValue(f: String => String): ConfigSourceEntry[Key] =
+    new ConfigSourceEntry(key, keyType, value.map(f))
+
   override def toString: String =
     s"ConfigSourceEntry($key, $keyType, $value)"
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSourceEntry.scala
@@ -37,7 +37,7 @@ sealed class ConfigSourceEntry[Key](
     * entry: ConfigSourceEntry[String] = ConfigSourceEntry(key, Environment, Right(value ))
     *
     * scala> entry.mapValue(_.trim)
-    * res0: ciris.ConfigSourceEntry[String] = ConfigSourceEntry(key, Environment, Right(value))
+    * res0: ConfigSourceEntry[String] = ConfigSourceEntry(key, Environment, Right(value))
     * }}}
     */
   def mapValue(f: String => String): ConfigSourceEntry[Key] =

--- a/modules/core/shared/src/main/scala/ciris/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/package.scala
@@ -3,7 +3,7 @@
   * get started is to bring it into scope with an import.<br>
   * If you are looking for a getting started guide, with examples and explanations, please refer to the [[https://cir.is/docs/basics usage guide]].
   */
-package object ciris extends LoadConfigs {
+package object ciris extends LoadConfigs with CirisPlatformSpecific {
 
   /**
     * Reads the environment variable with the specified key name,

--- a/tests/jvm/src/test/scala/ciris/CirisPlatformSpecificSpec.scala
+++ b/tests/jvm/src/test/scala/ciris/CirisPlatformSpecificSpec.scala
@@ -1,0 +1,37 @@
+package ciris
+
+final class CirisPlatformSpecificSpec extends JvmPropertySpec {
+  "CirisPlatformSpecific" when {
+    "reading a file" when {
+      "the file exists" when {
+        "the type can be read" should {
+          "return the expected value" in {
+            forAll { value: Int =>
+              withFile(s"$value\n") { (file, charset) =>
+                val fileName = file.toPath.toAbsolutePath.toString
+                fileWithName[Int](fileName, _.trim).value shouldBe Right(value)
+              }
+            }
+          }
+        }
+
+        "the type cannot be read" should {
+          "fail with an error" in {
+            forAll { value: Int =>
+              withFile(s"$value\n") { (file, charset) =>
+                val fileName = file.toPath.toAbsolutePath.toString
+                fileWithName[Int](fileName).value shouldBe a[Left[_, _]]
+              }
+            }
+          }
+        }
+      }
+
+      "the file does not exist" should {
+        "fail with an error" in {
+          fileWithName[Int]("/tmp/does-not-exist").value shouldBe a[Left[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/tests/jvm/src/test/scala/ciris/ConfigSourcePlatformSpecificSpec.scala
+++ b/tests/jvm/src/test/scala/ciris/ConfigSourcePlatformSpecificSpec.scala
@@ -1,0 +1,28 @@
+package ciris
+
+import java.io.{File => JFile}
+import java.nio.charset.Charset
+
+final class ConfigSourcePlatformSpecificSpec extends JvmPropertySpec {
+  "ConfigSourcePlatformSpecific" when {
+    "reading from a file" when {
+      "the file exists" should {
+        "return the file contents" in {
+          forAll { value: String =>
+            withFile(value) { (file, charset) =>
+              ConfigSource.File.read((file, charset)).value shouldBe Right(value)
+            }
+          }
+        }
+      }
+
+      "the file does not exist" should {
+        "return an error" in {
+          val key = (new JFile("/tmp/does-not-exist"), Charset.defaultCharset)
+          ConfigSource.File.read(key).value shouldBe a[Left[_, _]]
+        }
+      }
+    }
+  }
+
+}

--- a/tests/jvm/src/test/scala/ciris/JvmPropertySpec.scala
+++ b/tests/jvm/src/test/scala/ciris/JvmPropertySpec.scala
@@ -1,0 +1,16 @@
+package ciris
+
+import java.io.{FileWriter, File => JFile}
+import java.nio.charset.Charset
+
+class JvmPropertySpec extends PropertySpec {
+  def withFile[T](fileContents: String)(f: (JFile, Charset) => T): T = {
+    val file = JFile.createTempFile("ciris-", ".test")
+    file.delete()
+    file.deleteOnExit()
+
+    val writer = new FileWriter(file)
+    try { writer.write(fileContents) } finally { writer.close() }
+    try { f(file, Charset.defaultCharset) } finally { file.delete(); () }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/ConfigReaderSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigReaderSpec.scala
@@ -100,5 +100,20 @@ final class ConfigReaderSpec extends PropertySpec {
         }
       }
     }
+
+    "using mapEntryValue" should {
+      val f: String => String = _.take(1)
+      val reader = ConfigReader.identity.mapEntryValue(f)
+
+      "keep the error if there is one" in {
+        reader.read(nonExistingEntry) shouldBe a[Left[_, _]]
+      }
+
+      "map the entry value if there is one" in {
+        forAll { value: String =>
+          reader.read(existingEntry(value)) shouldBe Right(f(value))
+        }
+      }
+    }
   }
 }

--- a/tests/shared/src/test/scala/ciris/ConfigSourceEntrySpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigSourceEntrySpec.scala
@@ -10,5 +10,24 @@ final class ConfigSourceEntrySpec extends PropertySpec {
         }
       }
     }
+
+    "using mapValue" when {
+      "the value was read successfully" should {
+        "apply the function on the value" in {
+          forAll { value: String =>
+            val f: String => String = _.take(1)
+            val entry = existingEntry(value).mapValue(f)
+            entry.value shouldBe Right(f(value))
+          }
+        }
+      }
+
+      "the value was not read successfully" should {
+        "leave the value as it is" in {
+          val entry = nonExistingEntry.mapValue(_.take(1))
+          entry.value shouldBe nonExistingEntry.value
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Add `file` and `fileWithName` methods for reading the contents of files, optionally modifying the read file contents before attempting the type conversion, and optionally specifying a charset. Note that this is currently only implemented for the JVM. Also adds the following in support of the functionality: `ConfigKeyType#File`, `ConfigSource#File`, `ConfigReader#mapEntryValue`,  `ConfigSourceEntry#mapValue`.

```
❯ cat /tmp/num.txt
3
```

```
scala> import ciris._
import ciris._

scala> fileWithName[Int]("/tmp/num.txt")
res0: ciris.ConfigValue[Int] =
ConfigValue(Left(WrongType((/tmp/num.txt,UTF-8), 3
, Int, ConfigKeyType(file), Some(java.lang.NumberFormatException: For input string: "3
"))))

scala> fileWithName[Int]("/tmp/num.txt", _.trim)
res1: ciris.ConfigValue[Int] = ConfigValue(Right(3))
```