### PR TITLE
Add Secret class to avoid logging secrets

### DIFF
--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,3 +1,3 @@
 latestVersion in ThisBuild := "0.5.0"
-latestBinaryCompatibleVersion in ThisBuild := Some("0.5.0")
+latestBinaryCompatibleVersion in ThisBuild := None
 unreleasedModuleNames in ThisBuild := Set()

--- a/modules/core/js/src/main/scala/ciris/readers/ConfigReaders.scala
+++ b/modules/core/js/src/main/scala/ciris/readers/ConfigReaders.scala
@@ -1,7 +1,8 @@
 package ciris.readers
 
 trait ConfigReaders
-    extends DerivedConfigReaders
+    extends CirisConfigReaders
+    with DerivedConfigReaders
     with DurationConfigReaders
     with JavaNioCharsetConfigReaders
     with JavaUtilConfigReaders

--- a/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/readers/ConfigReaders.scala
@@ -1,7 +1,8 @@
 package ciris.readers
 
 trait ConfigReaders
-    extends DerivedConfigReaders
+    extends CirisConfigReaders
+    with DerivedConfigReaders
     with DurationConfigReaders
     with JavaIoConfigReaders
     with JavaNetConfigReaders

--- a/modules/core/shared/src/main/scala/ciris/Secret.scala
+++ b/modules/core/shared/src/main/scala/ciris/Secret.scala
@@ -1,0 +1,58 @@
+package ciris
+
+/**
+  * Used to denote that a configuration value is secret, and that it should not
+  * be included in any log output. By wrapping a value with `Secret`, the value
+  * will not be printed, but a `Secret(***)` placeholder will take its place.
+  *
+  * To create a new `Secret`, use the apply method in the companion object.
+  * {{{
+  * scala> Secret(123)
+  * res0: Secret[Int] = Secret(***)
+  * }}}
+  *
+  * The `equals`, `hashCode`, `copy`, and `unapply` methods are implemented.
+  * {{{
+  * scala> Secret(123) == Secret(123)
+  * res1: Boolean = true
+  *
+  * scala> Secret(123).copy("abc")
+  * res2: Secret[String] = Secret(***)
+  *
+  * scala> Secret(123) match { case Secret(value) => Secret(value + 1) }
+  * res3: Secret[Int] = Secret(***)
+  * }}}
+  *
+  * The original value can be retrieved; be careful to not include it in logs.
+  * {{{
+  * scala> Secret(123).value
+  * res4: Int = 123
+  * }}}
+  *
+  * @param value the original value which the `Secret` is wrapping
+  * @tparam A the type of the original value being wrapped
+  */
+final class Secret[A] private (val value: A) {
+  override def toString: String =
+    "Secret(***)"
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case Secret(a) => value == a
+      case _         => false
+    }
+
+  override def hashCode(): Int =
+    value.hashCode()
+
+  def copy[B](value: B = value): Secret[B] =
+    new Secret(value = value)
+}
+
+object Secret {
+  def apply[A](value: A): Secret[A] =
+    new Secret(value)
+
+  def unapply[A](secret: Secret[A]): Option[A] =
+    Some(secret.value)
+}

--- a/modules/core/shared/src/main/scala/ciris/readers/CirisConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/CirisConfigReaders.scala
@@ -1,0 +1,8 @@
+package ciris.readers
+
+import ciris.{ConfigReader, Secret}
+
+trait CirisConfigReaders {
+  implicit def secretConfigReader[A](implicit reader: ConfigReader[A]): ConfigReader[Secret[A]] =
+    reader.map(Secret.apply)
+}

--- a/tests/shared/src/test/scala/ciris/SecretSpec.scala
+++ b/tests/shared/src/test/scala/ciris/SecretSpec.scala
@@ -17,6 +17,20 @@ final class SecretSpec extends PropertySpec {
       }
     }
 
+    "not be equal if values are different" in {
+      forAll { (a: Int, b: Int) =>
+        whenever(a != b) {
+          Secret(a) shouldNot equal(Secret(b))
+        }
+      }
+    }
+
+    "not be equal if one is not a secret" in {
+      forAll { (a: Int, b: Int) =>
+        Secret(a) shouldNot equal(b)
+      }
+    }
+
     "have equal hash code to a copy with the same value" in {
       forAll { secret: Secret[Int] =>
         secret.hashCode shouldBe secret.copy().hashCode
@@ -33,6 +47,12 @@ final class SecretSpec extends PropertySpec {
       forAll { secret: Secret[Int] =>
         val value = secret match { case Secret(value) => value }
         value shouldBe secret.value
+      }
+    }
+
+    "be able to read secret values" in {
+      forAll { value: Int =>
+        readValue[Secret[Int]](value.toString) shouldBe Right(Secret(value))
       }
     }
   }

--- a/tests/shared/src/test/scala/ciris/SecretSpec.scala
+++ b/tests/shared/src/test/scala/ciris/SecretSpec.scala
@@ -1,0 +1,42 @@
+package ciris
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+
+final class SecretSpec extends PropertySpec {
+  "Secret" should {
+    "use a placeholder when represented as a string" in {
+      forAll { secret: Secret[Int] =>
+        secret.toString shouldBe "Secret(***)"
+      }
+    }
+
+    "be equal to a copy with the same value" in {
+      forAll { secret: Secret[Int] =>
+        secret shouldBe secret.copy()
+      }
+    }
+
+    "have equal hash code to a copy with the same value" in {
+      forAll { secret: Secret[Int] =>
+        secret.hashCode shouldBe secret.copy().hashCode
+      }
+    }
+
+    "be able to change type when copying" in {
+      forAll { secret: Secret[Int] =>
+        secret.copy(secret.value.toString) shouldBe Secret(secret.value.toString)
+      }
+    }
+
+    "be able to extract the value with pattern matching" in {
+      forAll { secret: Secret[Int] =>
+        val value = secret match { case Secret(value) => value }
+        value shouldBe secret.value
+      }
+    }
+  }
+
+  implicit def arbSecret[A: Arbitrary]: Arbitrary[Secret[A]] =
+    Arbitrary(arbitrary[A].map(Secret.apply))
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+version in ThisBuild := "0.6.0-SNAPSHOT"


### PR DESCRIPTION
Introduces `Secret[A]` which can wrap values to avoid secret configuration values in log output.

```scala
scala> import ciris._, ciris.refined._, eu.timepit.refined.types.string._
import ciris._
import ciris.refined._
import eu.timepit.refined.types.string._

scala> env[Secret[NonEmptyString]]("DATABASE_PASSWORD")
res0: ciris.ConfigValue[ciris.Secret[eu.timepit.refined.types.string.NonEmptyString]] = ConfigValue(Right(Secret(***)))
```