### PR TITLE
Clarify compatibility rules

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -87,8 +87,9 @@ s"""
  || $spireModuleName      | &#10003; $scalaPublishVersionsShortString | &#10003; 0.6 ($scalaPublishVersionsShortString) | &#65794;            |
  || $squantsModuleName    | &#10003; $scalaPublishVersionsShortString | &#10003; 0.6 ($scalaPublishVersionsShortString) | &#65794;            |
  |
- |Binary compatibility for the library is guaranteed between minor versions.  
- |For example, `$minorVersion.x` is binary compatible with `$minorVersion.y` for any `x` and `y`.
+ |Backwards binary compatibility for the library is guaranteed between minor versions.  
+ |For example, `$minorVersion.x` is backwards binary compatible with `$minorVersion.y` for any `x > y`.  
+ |More recent minor versions are drop-in replacements for earlier minor versions.
  """.stripMargin.trim
 )
 ```

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,9 @@ Refer to the table below for platform and version support across modules.
  ciris-spire      | &#10003; 2.10, 2.11, 2.12 | &#10003; 0.6 (2.10, 2.11, 2.12) | &#65794;            |
  ciris-squants    | &#10003; 2.10, 2.11, 2.12 | &#10003; 0.6 (2.10, 2.11, 2.12) | &#65794;            |
 
-Binary compatibility for the library is guaranteed between minor versions.  
-For example, `0.6.x` is binary compatible with `0.6.y` for any `x` and `y`.
+Backwards binary compatibility for the library is guaranteed between minor versions.  
+For example, `0.6.x` is backwards binary compatible with `0.6.y` for any `x > y`.  
+More recent minor versions are drop-in replacements for earlier minor versions.
 
 
 The only required module is `ciris-core`, the rest are optional library integrations.  


### PR DESCRIPTION
Backwards binary compatibility for the library is guaranteed between minor versions.  
For example, `0.6.x` is backwards binary compatible with `0.6.y` for any `x > y`.  
More recent minor versions are drop-in replacements for earlier minor versions.