### PR TITLE
Rename ConfigSourceEntry to ConfigEntry

### DIFF
--- a/docs/src/main/tut/docs/concepts/readme.md
+++ b/docs/src/main/tut/docs/concepts/readme.md
@@ -6,25 +6,25 @@ permalink: /docs/concepts
 ---
 
 # Core Concepts
-This section explains the core concepts in Ciris, including the types `ConfigSource`, `ConfigSourceEntry`, `ConfigKeyType`, `ConfigReader`, `ConfigError`, `ConfigErrors`, and `ConfigValue` and the methods `loadConfig`, `withValue`, `withValues`, `env`, `prop`, `arg`, and `read`. For [basic usage](/docs/basics), you do not need to have a complete understanding of these concepts, although it might be helpful. If you need to do some integration with Ciris, like creating a new [module](/docs/modules), defining a new [configuration source](/docs/sources), or writing a [custom reader](/docs/readers) to support new types, understanding these core concepts will be beneficial.
+This section explains the core concepts in Ciris, including the types `ConfigSource`, `ConfigEntry`, `ConfigKeyType`, `ConfigReader`, `ConfigError`, `ConfigErrors`, and `ConfigValue` and the methods `loadConfig`, `withValue`, `withValues`, `env`, `prop`, `arg`, and `read`. For [basic usage](/docs/basics), you do not need to have a complete understanding of these concepts, although it might be helpful. If you need to do some integration with Ciris, like creating a new [module](/docs/modules), defining a new [configuration source](/docs/sources), or writing a [custom reader](/docs/readers) to support new types, understanding these core concepts will be beneficial.
 
 ## Configuration Sources
-Configuration values can be read from different sources, represented by `ConfigSource`s, which are anything that can map keys of type `Key` to `String` values, like `Map[Int, String]` for example, and that return a `ConfigError` error if there was an error while reading the value (for example, when no value exists for a given key). A `ConfigSource` reads keys of type `ConfigKeyType`, which is simply a wrapper around the key name and type, for example `environment variable` and type `String`. `ConfigSource` returns a `ConfigSourceEntry`, which is the result of reading a key, including the read key and the `ConfigKeyType`. The abstract class `ConfigSource` is defined as follows.
+Configuration values can be read from different sources, represented by `ConfigSource`s, which are anything that can map keys of type `Key` to `String` values, like `Map[Int, String]` for example, and that return a `ConfigError` error if there was an error while reading the value (for example, when no value exists for a given key). A `ConfigSource` reads keys of type `ConfigKeyType`, which is simply a wrapper around the key name and type, for example `environment variable` and type `String`. `ConfigSource` returns a `ConfigEntry`, which is the result of reading a key, including the read key and the `ConfigKeyType`. The abstract class `ConfigSource` is defined as follows.
 
 ```scala
 abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
-  def read(key: Key): ConfigSourceEntry[Key]
+  def read(key: Key): ConfigEntry[Key]
 }
 ```
 
 Ciris provides `ConfigSource`s for environment variables, system properties, and command-line arguments in the core library. If you require other configuration sources, you can easily create your own. You can read more about `ConfigSource`s in the [Configuration Sources](/docs/sources) section.
 
 ## Configuration Readers
-Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigReader[A]`. `ConfigReader`s accept a `ConfigSourceEntry` from a source and tries to convert the `String` value into type `A`, returning a `ConfigError` error if the conversion was unsuccessful. The abstract class `ConfigReader` is defined as follows.
+Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigReader[A]`. `ConfigReader`s accept a `ConfigEntry` from a source and tries to convert the `String` value into type `A`, returning a `ConfigError` error if the conversion was unsuccessful. The abstract class `ConfigReader` is defined as follows.
 
 ```scala
 abstract class ConfigReader[Value] {
-  def read[Key](entry: ConfigSourceEntry[Key]): Either[ConfigError, Value]
+  def read[Key](entry: ConfigEntry[Key]): Either[ConfigError, Value]
 }
 ```
 

--- a/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -17,7 +17,7 @@ private[ciris] trait ConfigSourcePlatformSpecific {
           Source.fromFile(file, charset.name).mkString
       }
 
-    override def read(key: (JFile, Charset)): ConfigSourceEntry[(JFile, Charset), String] =
+    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String] =
       delegate.read(key)
   }
 }

--- a/modules/core/native/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/native/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -13,7 +13,7 @@ private[ciris] trait ConfigSourcePlatformSpecific {
           Source.fromFile(file, charset.name).mkString
       }
 
-    override def read(key: (JFile, Charset)): ConfigSourceEntry[(JFile, Charset), String] =
+    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String] =
       delegate.read(key)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
@@ -7,11 +7,11 @@ package ciris
   * type `Value`. Also includes the [[ConfigKeyType]] to be able to support
   * better error messages.
   *
-  * To create a [[ConfigSourceEntry]], use [[ConfigSourceEntry#apply]].
+  * To create a [[ConfigEntry]], use [[ConfigEntry#apply]].
   *
   * {{{
-  * scala> ConfigSourceEntry("key", ConfigKeyType.Environment, Right("value"))
-  * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Right(value))
+  * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
+  * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
   * }}}
   *
   * @param key the key which was read from the configuration source
@@ -20,7 +20,7 @@ package ciris
   * @tparam Key the type of the key
   * @tparam Value the type of the value
   */
-sealed class ConfigSourceEntry[Key, Value](
+sealed class ConfigEntry[Key, Value](
   val key: Key,
   val keyType: ConfigKeyType[Key],
   val value: Either[ConfigError, Value]
@@ -28,30 +28,30 @@ sealed class ConfigSourceEntry[Key, Value](
 
   /**
     * Transforms the value read from the configuration source by applying
-    * the specified function, returning a new [[ConfigSourceEntry]] which
+    * the specified function, returning a new [[ConfigEntry]] which
     * includes the modified value.
     *
     * @param f the function to apply to the read configuration value
-    * @return a new [[ConfigSourceEntry]] with the transformed value
+    * @return a new [[ConfigEntry]] with the transformed value
     * @example {{{
-    * scala> val entry = ConfigSourceEntry("key", ConfigKeyType.Environment, Right("value "))
-    * entry: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Right(value ))
+    * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value "))
+    * entry: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value ))
     *
     * scala> entry.mapValue(_.trim)
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Right(value))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
     * }}}
     */
-  def mapValue[A](f: Value => A): ConfigSourceEntry[Key, A] =
-    new ConfigSourceEntry(key, keyType, value.right.map(f))
+  def mapValue[A](f: Value => A): ConfigEntry[Key, A] =
+    new ConfigEntry(key, keyType, value.right.map(f))
 
   override def toString: String =
-    s"ConfigSourceEntry($key, $keyType, $value)"
+    s"ConfigEntry($key, $keyType, $value)"
 }
 
-object ConfigSourceEntry {
+object ConfigEntry {
 
   /**
-    * Creates a new [[ConfigSourceEntry]] representing an entry (key-value pair)
+    * Creates a new [[ConfigEntry]] representing an entry (key-value pair)
     * that has been read from a configuration source. The reading might have failed,
     * represented by wrapping the value in an `Either[ConfigError, String]`. Values are
     * always of type `String`, while the `Key` can be different. Also includes the
@@ -61,17 +61,17 @@ object ConfigSourceEntry {
     * @param keyType the type of keys the configuration source reads
     * @param value the value which was read or a [[ConfigError]]
     * @tparam Key the type of key
-    * @return a new [[ConfigSourceEntry]] using the specified arguments
+    * @return a new [[ConfigEntry]] using the specified arguments
     * @example {{{
-    * scala> ConfigSourceEntry("key", ConfigKeyType.Environment, Right("value"))
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Right(value))
+    * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
     * }}}
     */
   def apply[Key, Value](
     key: Key,
     keyType: ConfigKeyType[Key],
     value: Either[ConfigError, Value]
-  ): ConfigSourceEntry[Key, Value] = {
-    new ConfigSourceEntry(key, keyType, value)
+  ): ConfigEntry[Key, Value] = {
+    new ConfigEntry(key, keyType, value)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -17,14 +17,14 @@ import scala.util.{Failure, Success, Try}
   * source: ConfigSource[String] = ConfigSource(ConfigKeyType(identity key))
   *
   * scala> source.read("key")
-  * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, ConfigKeyType(identity key), Right(key))
+  * res0: ConfigEntry[String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
   * }}}
   *
   * There are also convenience methods in the companion object for creating
   * sources from some different constructs, like [[ConfigSource#fromOption]],
   * [[ConfigSource#fromMap]], [[ConfigSource#fromTry]], and more.
   *
-  * The [[read]] method returns a [[ConfigSourceEntry]], which is the key-value
+  * The [[read]] method returns a [[ConfigEntry]], which is the key-value
   * pair that was read, along with the [[ConfigKeyType]] of the [[ConfigSource]].
   *
   * @param keyType the [[ConfigKeyType]] representing the key type and name
@@ -34,18 +34,18 @@ abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
 
   /**
     * Reads the specified key of type `Key` and returns the key along
-    * with the value in a [[ConfigSourceEntry]]. If there was an error
-    * while reading the value, [[ConfigSourceEntry#value]] will have
+    * with the value in a [[ConfigEntry]]. If there was an error
+    * while reading the value, [[ConfigEntry#value]] will have
     * a [[ConfigError]] instead of the value.
     *
     * @param key the key to read from the configuration source
-    * @return a [[ConfigSourceEntry]] containing the key-value pair
+    * @return a [[ConfigEntry]] containing the key-value pair
     * @example {{{
     * scala> ConfigSource.Environment.read("key")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
-  def read(key: Key): ConfigSourceEntry[Key, String]
+  def read(key: Key): ConfigEntry[Key, String]
 }
 
 object ConfigSource extends ConfigSourcePlatformSpecific {
@@ -64,14 +64,14 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(ConfigKeyType(identity key))
     *
     * scala> source.read("key")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, ConfigKeyType(identity key), Right(key))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
     * }}}
     */
   def apply[Key](keyType: ConfigKeyType[Key])(
     read: Key => Either[ConfigError, String]): ConfigSource[Key] = {
-    val entry = (key: Key) => ConfigSourceEntry(key, keyType, read(key))
+    val entry = (key: Key) => ConfigEntry(key, keyType, read(key))
     new ConfigSource(keyType) {
-      override def read(key: Key): ConfigSourceEntry[Key, String] = entry(key)
+      override def read(key: Key): ConfigEntry[Key, String] = entry(key)
       override def toString: String = s"ConfigSource($keyType)"
     }
   }
@@ -90,7 +90,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromOption[Key](keyType: ConfigKeyType[Key])(
@@ -127,10 +127,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key1")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key1, Environment, Left(ConfigError(error)))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key1, Environment, Left(ConfigError(error)))
     *
     * scala> source.read("key2")
-    * res1: ConfigSourceEntry[String, String] = ConfigSourceEntry(key2, Environment, Left(ConfigError(error)))
+    * res1: ConfigEntry[String, String] = ConfigEntry(key2, Environment, Left(ConfigError(error)))
     * }}}
     */
   def failed[Key](keyType: ConfigKeyType[Key])(error: ConfigError): ConfigSource[Key] =
@@ -149,7 +149,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromMap[Key](keyType: ConfigKeyType[Key])(map: Map[Key, String]): ConfigSource[Key] =
@@ -170,13 +170,13 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigSourceEntry[Int, String] = ConfigSourceEntry(0, Argument, Right(def))
+    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(def))
     *
     * scala> source.read(1)
-    * res1: ConfigSourceEntry[Int, String] = ConfigSourceEntry(1, Argument, Right(ghi))
+    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Right(ghi))
     *
     * scala> source.read(2)
-    * res2: ConfigSourceEntry[Int, String] = ConfigSourceEntry(2, Argument, Left(MissingKey(2, Argument)))
+    * res2: ConfigEntry[Int, String] = ConfigEntry(2, Argument, Left(MissingKey(2, Argument)))
     * }}}
     */
   def fromEntries[Key](keyType: ConfigKeyType[Key])(entries: (Key, String)*): ConfigSource[Key] =
@@ -197,10 +197,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigSourceEntry[Int, String] = ConfigSourceEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigSourceEntry[Int, String] = ConfigSourceEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def fromTry[Key](keyType: ConfigKeyType[Key])(read: Key => Try[String]): ConfigSource[Key] =
@@ -226,10 +226,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Property)
     *
     * scala> source.read("key")
-    * res0: ConfigSourceEntry[String, String] = ConfigSourceEntry(key, Property, Left(MissingKey(key, Property)))
+    * res0: ConfigEntry[String, String] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
     *
     * scala> source.read("")
-    * res1: ConfigSourceEntry[String, String] = ConfigSourceEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
+    * res1: ConfigEntry[String, String] = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
     * }}}
     */
   def fromTryOption[Key](keyType: ConfigKeyType[Key])(
@@ -256,10 +256,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigSourceEntry[Int, String] = ConfigSourceEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigSourceEntry[Int, String] = ConfigSourceEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def catchNonFatal[Key](keyType: ConfigKeyType[Key])(read: Key => String): ConfigSource[Key] =
@@ -279,10 +279,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigSourceEntry[Int, String] = ConfigSourceEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigSourceEntry[Int, String] = ConfigSourceEntry(1, Argument, Left(MissingKey(1, Argument)))
+    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
     * }}}
     */
   def byIndex(keyType: ConfigKeyType[Int])(indexedSeq: IndexedSeq[String]): ConfigSource[Int] =
@@ -300,7 +300,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     private val delegate: ConfigSource[String] =
       ConfigSource.fromMap(keyType)(sys.env)
 
-    override def read(key: String): ConfigSourceEntry[String, String] =
+    override def read(key: String): ConfigEntry[String, String] =
       delegate.read(key)
   }
 
@@ -311,7 +311,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     private val delegate: ConfigSource[String] =
       ConfigSource.fromTryOption(keyType)(key => Try(sys.props.get(key)))
 
-    override def read(key: String): ConfigSourceEntry[String, String] =
+    override def read(key: String): ConfigEntry[String, String] =
       delegate.read(key)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
@@ -1,11 +1,11 @@
 package ciris.readers
 
-import ciris.{ConfigError, ConfigReader, ConfigSourceEntry}
+import ciris.{ConfigError, ConfigReader, ConfigEntry}
 
 trait DerivedConfigReaders {
   implicit def optionConfigReader[Value: ConfigReader]: ConfigReader[Option[Value]] =
     new ConfigReader[Option[Value]] {
-      override def read[Key](entry: ConfigSourceEntry[Key, String]): Either[ConfigError, Option[Value]] =
+      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, Option[Value]] =
         entry.value.fold(_ => Right(None), _ => ConfigReader[Value].read(entry).right.map(Some.apply))
     }
 }

--- a/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/readers/EnumeratumConfigReaders.scala
+++ b/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/readers/EnumeratumConfigReaders.scala
@@ -3,7 +3,7 @@ package ciris.enumeratum.readers
 import _root_.enumeratum._
 import _root_.enumeratum.values._
 import ciris.ConfigError.wrongType
-import ciris.{ConfigError, ConfigReader, ConfigSourceEntry}
+import ciris.{ConfigError, ConfigReader, ConfigEntry}
 
 import scala.reflect.ClassTag
 
@@ -13,7 +13,7 @@ trait EnumeratumConfigReaders {
     To: ClassTag
   ](f: From => Option[To]): ConfigReader[To] =
     new ConfigReader[To] {
-      override def read[Key](entry: ConfigSourceEntry[Key, String]): Either[ConfigError, To] =
+      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, To] =
         ConfigReader[From].read(entry).right.flatMap { value =>
           f(value) match {
             case Some(to) => Right(to)

--- a/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
+++ b/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
@@ -1,12 +1,12 @@
 package ciris.generic.readers
 
-import ciris.{ConfigError, ConfigReader, ConfigSourceEntry}
+import ciris.{ConfigError, ConfigReader, ConfigEntry}
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HNil, Inl, Inr, Lazy}
 
 trait GenericConfigReaders {
   implicit val cNilConfigReader: ConfigReader[CNil] =
     new ConfigReader[CNil] {
-      override def read[Key](entry: ConfigSourceEntry[Key, String]): Either[ConfigError, CNil] =
+      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, CNil] =
         Left(ConfigError(s"Could not find any valid coproduct choice while reading ${entry.keyType.name} [${entry.key}]"))
     }
 
@@ -15,7 +15,7 @@ trait GenericConfigReaders {
     readB: ConfigReader[B]
   ): ConfigReader[A :+: B] =
     new ConfigReader[A :+: B] {
-      override def read[Key](entry: ConfigSourceEntry[Key, String]): Either[ConfigError, A :+: B] =
+      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, A :+: B] =
         readA.value.read(entry) match {
           case Right(a) => Right(Inl(a))
           case Left(aError) =>

--- a/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
@@ -1,12 +1,12 @@
 package ciris
 
-final class ConfigSourceEntrySpec extends PropertySpec {
-  "ConfigSourceEntry" when {
+final class ConfigEntrySpec extends PropertySpec {
+  "ConfigEntry" when {
     "converting to String" should {
       "include the key, keyType, and value" in {
         forAll { value: String =>
           existingEntry(value).toString shouldBe
-            s"ConfigSourceEntry(key, ConfigKeyType(test key), Right($value))"
+            s"ConfigEntry(key, ConfigKeyType(test key), Right($value))"
         }
       }
     }

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -40,13 +40,13 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks with Eithe
   def readNonExistingValue[A](implicit reader: ConfigReader[A]): Either[ConfigError, A] =
     reader.read(emptySource.read("key"))
 
-  def existingEntry(value: String): ConfigSourceEntry[String, String] =
+  def existingEntry(value: String): ConfigEntry[String, String] =
     sourceWith("key" -> value).read("key")
 
   val emptySource: ConfigSource[String] =
     sourceWith()
 
-  val nonExistingEntry: ConfigSourceEntry[String, String] =
+  val nonExistingEntry: ConfigEntry[String, String] =
     emptySource.read("key")
 
   def sourceWith(entries: (String, String)*): ConfigSource[String] =


### PR DESCRIPTION
This is in preparation of unifying `ConfigValue` and `ConfigSourceEntry` into `ConfigEntry`.