### PR TITLE
Add ConfigEntry#sourceValue

### DIFF
--- a/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -17,7 +17,7 @@ private[ciris] trait ConfigSourcePlatformSpecific {
           Source.fromFile(file, charset.name).mkString
       }
 
-    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String] =
+    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String, String] =
       delegate.read(key)
   }
 }

--- a/modules/core/native/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
+++ b/modules/core/native/src/main/scala/ciris/ConfigSourcePlatformSpecific.scala
@@ -13,7 +13,7 @@ private[ciris] trait ConfigSourcePlatformSpecific {
           Source.fromFile(file, charset.name).mkString
       }
 
-    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String] =
+    override def read(key: (JFile, Charset)): ConfigEntry[(JFile, Charset), String, String] =
       delegate.read(key)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
@@ -1,77 +1,108 @@
 package ciris
 
 /**
-  * Represents an entry (key-value pair) that has been read from a configuration
-  * source. The reading might have failed, represented by wrapping the value in
-  * an `Either[ConfigError, Value]`. Keys are of type `Key` and values are of
-  * type `Value`. Also includes the [[ConfigKeyType]] to be able to support
-  * better error messages.
-  *
+  * [[ConfigEntry]] represents an entry (key-value pair) from a configuration
+  * source, with support for transforming the value. The value might not have
+  * been retrieved or transformed successfully, represented by wrapping the
+  * value in `Either[ConfigError, V]`. The key is of type `K` and the value
+  * is of type `V`. The original value from the source is left unmodified
+  * and is of type `S`. The type of the key is described with the
+  * included [[ConfigKeyType]].<br>
+  * <br>
   * To create a [[ConfigEntry]], use [[ConfigEntry#apply]].
-  *
   * {{{
   * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-  * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
+  * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value))
   * }}}
   *
-  * @param key the key which was read from the configuration source
-  * @param keyType the type of keys the configuration source reads
-  * @param value the value which was read or a [[ConfigError]]
-  * @tparam Key the type of the key
-  * @tparam Value the type of the value
+  * @param key the key which was retrieved from the configuration source
+  * @param keyType the type of keys which the configuration source supports
+  * @param sourceValue the original unmodified value from the configuration source
+  * @param value the source value with zero or more transformations applied to it
+  * @tparam K the type of the key
+  * @tparam S the type of the source value
+  * @tparam V the type of the value
   */
-sealed class ConfigEntry[Key, Value](
-  val key: Key,
-  val keyType: ConfigKeyType[Key],
-  val value: Either[ConfigError, Value]
+final class ConfigEntry[K, S, V] private (
+  val key: K,
+  val keyType: ConfigKeyType[K],
+  val sourceValue: Either[ConfigError, S],
+  val value: Either[ConfigError, V]
 ) {
 
   /**
-    * Transforms the value read from the configuration source by applying
-    * the specified function, returning a new [[ConfigEntry]] which
-    * includes the modified value.
+    * Transforms the value of this [[ConfigEntry]] by applying the specified
+    * function, returning a new [[ConfigEntry]] with the modified value. The
+    * existing [[ConfigEntry]] and all other properties are left unmodified.
     *
-    * @param f the function to apply to the read configuration value
-    * @return a new [[ConfigEntry]] with the transformed value
+    * @param f the function to apply to the value
+    * @return a new [[ConfigEntry]] with the modified value
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value "))
-    * entry: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value ))
+    * entry: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value ))
     *
-    * scala> entry.mapValue(_.trim)
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
+    * scala> entry.mapValue(_.right.map(_.trim))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
+    *
+    * scala> entry.mapValueRight(_.trim)
+    * res1: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
+    * }}}
+    * @see [[mapValueRight]]
+    */
+  def mapValue[A](f: Either[ConfigError, V] => Either[ConfigError, A]): ConfigEntry[K, S, A] =
+    new ConfigEntry(key, keyType, sourceValue, f(value))
+
+  /**
+    * Transforms the value of this [[ConfigEntry]] if it is available, by
+    * applying the specified function, returning a new [[ConfigEntry]]
+    * with the modified value. The existing [[ConfigEntry]] and all
+    * other properties are left unmodified.
+    *
+    * @param f the function to apply to the value
+    * @return a new [[ConfigEntry]] with the modified value;
+    *         or a [[ConfigError]] if the value is not available
+    * @example {{{
+    * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value "))
+    * entry: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value ))
+    *
+    * scala> entry.mapValueRight(_.trim)
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
     * }}}
     */
-  def mapValue[A](f: Value => A): ConfigEntry[Key, A] =
-    new ConfigEntry(key, keyType, value.right.map(f))
+  def mapValueRight[A](f: V => A): ConfigEntry[K, S, A] =
+    mapValue(_.right.map(f))
 
-  override def toString: String =
-    s"ConfigEntry($key, $keyType, $value)"
+  override def toString: String = {
+    if(sourceValue == value) s"ConfigEntry($key, $keyType, $value)"
+    else s"ConfigEntry($key, $keyType, $sourceValue, $value)"
+  }
 }
 
 object ConfigEntry {
 
   /**
-    * Creates a new [[ConfigEntry]] representing an entry (key-value pair)
-    * that has been read from a configuration source. The reading might have failed,
-    * represented by wrapping the value in an `Either[ConfigError, String]`. Values are
-    * always of type `String`, while the `Key` can be different. Also includes the
-    * [[ConfigKeyType]] to be able to support better error messages.
+    * Creates a new [[ConfigEntry]] representing an entry (key-value pair) from a
+    * configuration source. The value might not have been retrieved successfully,
+    * represented by wrapping the value in `Either[ConfigError, S]`. The key is
+    * of type `K` and the source value is of type `S`. The type of the key is
+    * described with the [[ConfigKeyType]].
     *
-    * @param key the key which was read from the configuration source
-    * @param keyType the type of keys the configuration source reads
-    * @param value the value which was read or a [[ConfigError]]
-    * @tparam Key the type of key
-    * @return a new [[ConfigEntry]] using the specified arguments
+    * @param key the key which was retrieved from the configuration source
+    * @param keyType the type of keys which the configuration source supports
+    * @param sourceValue the value for the key from the configuration source
+    * @tparam K the type of the key
+    * @tparam S the type of the source value
+    * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Right(value))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Right(value))
     * }}}
     */
-  def apply[Key, Value](
-    key: Key,
-    keyType: ConfigKeyType[Key],
-    value: Either[ConfigError, Value]
-  ): ConfigEntry[Key, Value] = {
-    new ConfigEntry(key, keyType, value)
+  def apply[K, S](
+    key: K,
+    keyType: ConfigKeyType[K],
+    sourceValue: Either[ConfigError, S]
+  ): ConfigEntry[K, S, S] = {
+    new ConfigEntry(key, keyType, sourceValue, sourceValue)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success, Try}
   * source: ConfigSource[String] = ConfigSource(ConfigKeyType(identity key))
   *
   * scala> source.read("key")
-  * res0: ConfigEntry[String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
+  * res0: ConfigEntry[String, String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
   * }}}
   *
   * There are also convenience methods in the companion object for creating
@@ -42,10 +42,10 @@ abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
     * @return a [[ConfigEntry]] containing the key-value pair
     * @example {{{
     * scala> ConfigSource.Environment.read("key")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
-  def read(key: Key): ConfigEntry[Key, String]
+  def read(key: Key): ConfigEntry[Key, String, String]
 }
 
 object ConfigSource extends ConfigSourcePlatformSpecific {
@@ -64,14 +64,14 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(ConfigKeyType(identity key))
     *
     * scala> source.read("key")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
     * }}}
     */
   def apply[Key](keyType: ConfigKeyType[Key])(
     read: Key => Either[ConfigError, String]): ConfigSource[Key] = {
     val entry = (key: Key) => ConfigEntry(key, keyType, read(key))
     new ConfigSource(keyType) {
-      override def read(key: Key): ConfigEntry[Key, String] = entry(key)
+      override def read(key: Key): ConfigEntry[Key, String, String] = entry(key)
       override def toString: String = s"ConfigSource($keyType)"
     }
   }
@@ -90,7 +90,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromOption[Key](keyType: ConfigKeyType[Key])(
@@ -127,10 +127,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key1")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key1, Environment, Left(ConfigError(error)))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key1, Environment, Left(ConfigError(error)))
     *
     * scala> source.read("key2")
-    * res1: ConfigEntry[String, String] = ConfigEntry(key2, Environment, Left(ConfigError(error)))
+    * res1: ConfigEntry[String, String, String] = ConfigEntry(key2, Environment, Left(ConfigError(error)))
     * }}}
     */
   def failed[Key](keyType: ConfigKeyType[Key])(error: ConfigError): ConfigSource[Key] =
@@ -149,7 +149,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Environment)
     *
     * scala> source.read("key")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromMap[Key](keyType: ConfigKeyType[Key])(map: Map[Key, String]): ConfigSource[Key] =
@@ -170,13 +170,13 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(def))
+    * res0: ConfigEntry[Int, String, String] = ConfigEntry(0, Argument, Right(def))
     *
     * scala> source.read(1)
-    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Right(ghi))
+    * res1: ConfigEntry[Int, String, String] = ConfigEntry(1, Argument, Right(ghi))
     *
     * scala> source.read(2)
-    * res2: ConfigEntry[Int, String] = ConfigEntry(2, Argument, Left(MissingKey(2, Argument)))
+    * res2: ConfigEntry[Int, String, String] = ConfigEntry(2, Argument, Left(MissingKey(2, Argument)))
     * }}}
     */
   def fromEntries[Key](keyType: ConfigKeyType[Key])(entries: (Key, String)*): ConfigSource[Key] =
@@ -197,10 +197,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * res1: ConfigEntry[Int, String, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def fromTry[Key](keyType: ConfigKeyType[Key])(read: Key => Try[String]): ConfigSource[Key] =
@@ -226,10 +226,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[String] = ConfigSource(Property)
     *
     * scala> source.read("key")
-    * res0: ConfigEntry[String, String] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
+    * res0: ConfigEntry[String, String, String] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
     *
     * scala> source.read("")
-    * res1: ConfigEntry[String, String] = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
+    * res1: ConfigEntry[String, String, String] = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
     * }}}
     */
   def fromTryOption[Key](keyType: ConfigKeyType[Key])(
@@ -256,10 +256,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * res1: ConfigEntry[Int, String, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def catchNonFatal[Key](keyType: ConfigKeyType[Key])(read: Key => String): ConfigSource[Key] =
@@ -279,10 +279,10 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * source: ConfigSource[Int] = ConfigSource(Argument)
     *
     * scala> source.read(0)
-    * res0: ConfigEntry[Int, String] = ConfigEntry(0, Argument, Right(a))
+    * res0: ConfigEntry[Int, String, String] = ConfigEntry(0, Argument, Right(a))
     *
     * scala> source.read(1)
-    * res1: ConfigEntry[Int, String] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
+    * res1: ConfigEntry[Int, String, String] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
     * }}}
     */
   def byIndex(keyType: ConfigKeyType[Int])(indexedSeq: IndexedSeq[String]): ConfigSource[Int] =
@@ -300,7 +300,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     private val delegate: ConfigSource[String] =
       ConfigSource.fromMap(keyType)(sys.env)
 
-    override def read(key: String): ConfigEntry[String, String] =
+    override def read(key: String): ConfigEntry[String, String, String] =
       delegate.read(key)
   }
 
@@ -311,7 +311,7 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     private val delegate: ConfigSource[String] =
       ConfigSource.fromTryOption(keyType)(key => Try(sys.props.get(key)))
 
-    override def read(key: String): ConfigEntry[String, String] =
+    override def read(key: String): ConfigEntry[String, String, String] =
       delegate.read(key)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -118,7 +118,7 @@ object ConfigValue {
     source: ConfigSource[Key],
     reader: ConfigReader[Value]
   ): ConfigValue[Value] = {
-    ConfigValue(reader.read[Key](source.read(key)))
+    ConfigValue(reader.read[Key, String](source.read(key)))
   }
 
   /**

--- a/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
+++ b/modules/core/shared/src/main/scala/ciris/readers/DerivedConfigReaders.scala
@@ -5,7 +5,7 @@ import ciris.{ConfigError, ConfigReader, ConfigEntry}
 trait DerivedConfigReaders {
   implicit def optionConfigReader[Value: ConfigReader]: ConfigReader[Option[Value]] =
     new ConfigReader[Option[Value]] {
-      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, Option[Value]] =
+      override def read[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, Option[Value]] =
         entry.value.fold(_ => Right(None), _ => ConfigReader[Value].read(entry).right.map(Some.apply))
     }
 }

--- a/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/readers/EnumeratumConfigReaders.scala
+++ b/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/readers/EnumeratumConfigReaders.scala
@@ -13,7 +13,7 @@ trait EnumeratumConfigReaders {
     To: ClassTag
   ](f: From => Option[To]): ConfigReader[To] =
     new ConfigReader[To] {
-      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, To] =
+      override def read[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, To] =
         ConfigReader[From].read(entry).right.flatMap { value =>
           f(value) match {
             case Some(to) => Right(to)

--- a/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
+++ b/modules/generic/shared/src/main/scala/ciris/generic/readers/GenericConfigReaders.scala
@@ -6,7 +6,7 @@ import shapeless.{:+:, ::, CNil, Coproduct, Generic, HNil, Inl, Inr, Lazy}
 trait GenericConfigReaders {
   implicit val cNilConfigReader: ConfigReader[CNil] =
     new ConfigReader[CNil] {
-      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, CNil] =
+      override def read[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, CNil] =
         Left(ConfigError(s"Could not find any valid coproduct choice while reading ${entry.keyType.name} [${entry.key}]"))
     }
 
@@ -15,7 +15,7 @@ trait GenericConfigReaders {
     readB: ConfigReader[B]
   ): ConfigReader[A :+: B] =
     new ConfigReader[A :+: B] {
-      override def read[Key](entry: ConfigEntry[Key, String]): Either[ConfigError, A :+: B] =
+      override def read[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, A :+: B] =
         readA.value.read(entry) match {
           case Right(a) => Right(Inl(a))
           case Left(aError) =>

--- a/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
@@ -16,7 +16,7 @@ final class ConfigEntrySpec extends PropertySpec {
         "apply the function on the value" in {
           forAll { value: String =>
             val f: String => String = _.take(1)
-            val entry = existingEntry(value).mapValue(f)
+            val entry = existingEntry(value).mapValueRight(f)
             entry.value shouldBe Right(f(value))
           }
         }
@@ -24,7 +24,7 @@ final class ConfigEntrySpec extends PropertySpec {
 
       "the value was not read successfully" should {
         "leave the value as it is" in {
-          val entry = nonExistingEntry.mapValue(_.take(1))
+          val entry = nonExistingEntry.mapValueRight(_.take(1))
           entry.value shouldBe nonExistingEntry.value
         }
       }

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -40,13 +40,13 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks with Eithe
   def readNonExistingValue[A](implicit reader: ConfigReader[A]): Either[ConfigError, A] =
     reader.read(emptySource.read("key"))
 
-  def existingEntry(value: String): ConfigEntry[String, String] =
+  def existingEntry(value: String): ConfigEntry[String, String, String] =
     sourceWith("key" -> value).read("key")
 
   val emptySource: ConfigSource[String] =
     sourceWith()
 
-  val nonExistingEntry: ConfigEntry[String, String] =
+  val nonExistingEntry: ConfigEntry[String, String, String] =
     emptySource.read("key")
 
   def sourceWith(entries: (String, String)*): ConfigSource[String] =


### PR DESCRIPTION
- Change `ConfigEntry` to include the original unmodified source value.
  `ConfigEntry[K, V]` has been changed to `ConfigEntry[K, S, V]`.
- Change `ConfigEntry` to be a `final class` with `private` constructor.
  Use the `ConfigEntry#apply` method to create instances of `ConfigEntry`.
- Rename the previous `ConfigEntry#mapValue[A]` to `mapValueRight[A]`.
- Add `ConfigEntry#mapValue[A]` for `Either[ConfigError, V] => Either[ConfigError, A]`.
- Change `ConfigSouce#toString` to include both the source value and the value if they are different.