### PR TITLE
Parameterise ConfigDecoder on source value type

### DIFF
--- a/docs/src/main/tut/docs/concepts/readme.md
+++ b/docs/src/main/tut/docs/concepts/readme.md
@@ -20,20 +20,20 @@ abstract class ConfigSource[Key](val keyType: ConfigKeyType[Key]) {
 Ciris provides `ConfigSource`s for environment variables, system properties, and command-line arguments in the core library. If you require other configuration sources, you can easily create your own. You can read more about `ConfigSource`s in the [Configuration Sources](/docs/sources) section.
 
 ## Configuration Decoders
-Values read from a `ConfigSource` can be converted into another type `A` using a `ConfigDecoder[A]`. `ConfigDecoders`s accept a `ConfigEntry` from a source and tries to convert the `String` value into type `A`, returning a `ConfigError` error if the conversion was unsuccessful. The abstract class `ConfigDecoder` is defined as follows.
+Values of type `A` retrieved from a `ConfigSource` can be converted into another type `B` using a `ConfigDecoder[A, B]`. `ConfigDecoders`s accept a `ConfigEntry` from a source and tries to convert the `A` value into type `B`, returning a `ConfigError` error if the conversion was unsuccessful. The abstract class `ConfigDecoder` is defined as follows.
 
 ```scala
-abstract class ConfigDecoder[V] {
+abstract class ConfigDecoder[A, B] {
   def decode[K, S](
-    entry: ConfigEntry[K, S, String]
-  ): Either[ConfigError, V]
+    entry: ConfigEntry[K, S, A]
+  ): Either[ConfigError, B]
 }
 ```
 
 Ciris provides `ConfigDecoder` instances for many types in the standard library, and for third-party library types in separate modules. Modules like `ciris-generic` use [shapeless](https://github.com/milessabin/shapeless) to derive `ConfigDecoder` instances for certain types, like case classes with one argument and [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html). For more information on Ciris modules, see [Modules Overview](/docs/modules). You can also easily create your own `ConfigDecoder`s, as described in the [Custom Decoders](/docs/decoders) section.
 
 ## Configuration Values
-A configuration value read for a specific key, from a `ConfigSource`, and converted to type `A` using a `ConfigDecoder[A]`, results in a `ConfigValue[A]`, which is a thin wrapper around an `Either[ConfigError, A]` instance. Ciris provides methods like `env`, `prop`, `arg`, and `read` for reading `ConfigValue`s from environment variables, system properties, command-line arguments, and other configuration sources. `ConfigValue`s are used internally to deal with error accumulation, and when loading configurations you'll typically see `ConfigErrors`, which is the result of error accumulation using `ConfigValue`s.
+A configuration value of type `A` read for a specific key, from a `ConfigSource`, and converted to type `B` using a `ConfigDecoder[A, B]`, results in a `ConfigValue[B]`, which is a thin wrapper around an `Either[ConfigError, B]` instance. Ciris provides methods like `env`, `prop`, `arg`, and `read` for reading `ConfigValue`s from environment variables, system properties, command-line arguments, and other configuration sources. `ConfigValue`s are used internally to deal with error accumulation, and when loading configurations you'll typically see `ConfigErrors`, which is the result of error accumulation using `ConfigValue`s.
 
 ## Loading Configurations
 The `loadConfig` and `withValues` (and `withValue`) methods allow you to combine multiple `ConfigValue`s, while accumulating errors, and using those values to create your configuration. The difference between them is that `withValues` declares a dependency required to be able to use `loadConfig` (think `flatMap`), while `loadConfig` loads your configuration using `ConfigValue`s. The `withValues` method is useful, for example, when dealing with [Multiple Environments](/docs/environments).

--- a/docs/src/main/tut/docs/readers/readme.md
+++ b/docs/src/main/tut/docs/readers/readme.md
@@ -28,10 +28,10 @@ We would now like to load `Odd` values using Ciris. If we try and do this straig
 env[Odd]("ODD_VALUE")
 ```
 
-This means we'll have to define a custom implicit `ConfigDecoder[Odd]` instance. The [`ConfigDecoder`](https://cir.is/api/ciris/ConfigDecoder$.html) companion object provides some helper methods for creating `ConfigDecoder`s. In this case, we'll rely on the default `ConfigDecoder[Int]` instance to read an `Int` and we will then try to convert the `Int` to an `Odd` instance using the `mapOption` method. Most `ConfigDecoder` methods accept a `typeName` argument which is the name of the type you're reading. Depending on which Scala version and which platform (Scala, Scala.js, &hellip;) you run on, you may be able to use [type tags](http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html). In this case, and cases where you don't have type parameters, it's simple enough to just provide the type name.
+This means we'll have to define a custom implicit `ConfigDecoder[String, Odd]` instance. The [`ConfigDecoder`](https://cir.is/api/ciris/ConfigDecoder$.html) companion object provides some helper methods for creating `ConfigDecoder`s. In this case, we'll rely on the existing `ConfigDecoder[String, Int]` instance to decode an `Int`, and we will then try to convert the `Int` to an `Odd` instance using the `mapOption` method. Most `ConfigDecoder` methods accept a `typeName` argument which is the name of the type you're reading. Depending on which Scala version and which platform (Scala, Scala.js, Scala Native) you run on, you may be able to use [type tags](http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html). In this case, and cases where you don't have type parameters, it's simple enough to just provide the type name.
 
 ```tut:book
-implicit def oddConfigDecoder(implicit decoder: ConfigDecoder[Int]) =
+implicit def oddConfigDecoder(implicit decoder: ConfigDecoder[String, Int]) =
   decoder.mapOption("Odd")(odd)
 ```
 

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -25,14 +25,14 @@ private[ciris] trait CirisPlatformSpecific {
     * res0: ConfigValue[Double] = ConfigValue(Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
     * }}}
     */
-  def file[Value: ConfigDecoder](
+  def file[Value](
     file: File,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  ): ConfigValue[Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] = {
     ConfigValue((file, charset))(
       ConfigSource.File,
-      ConfigDecoder[Value]
+      ConfigDecoder[String, Value]
         .mapEntryValue(modifyFileContents)
     )
   }
@@ -57,11 +57,11 @@ private[ciris] trait CirisPlatformSpecific {
     * res0: ConfigValue[Double] = ConfigValue(Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
     * }}}
     */
-  def fileWithName[Value: ConfigDecoder](
+  def fileWithName[Value](
     name: String,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  ): ConfigValue[Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] = {
     this.file(new File(name), modifyFileContents, charset)
   }
 }

--- a/modules/core/jvm/src/main/scala/ciris/decoders/JavaIoConfigDecoders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/decoders/JavaIoConfigDecoders.scala
@@ -5,6 +5,6 @@ import java.io.File
 import ciris.ConfigDecoder
 
 trait JavaIoConfigDecoders {
-  implicit val fileConfigDecoder: ConfigDecoder[File] =
-    ConfigDecoder.catchNonFatal("File")(new File(_))
+  implicit val fileConfigDecoder: ConfigDecoder[String, File] =
+    ConfigDecoder.catchNonFatal[String]("File")(new File(_))
 }

--- a/modules/core/jvm/src/main/scala/ciris/decoders/JavaNetConfigDecoders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/decoders/JavaNetConfigDecoders.scala
@@ -3,15 +3,14 @@ package ciris.decoders
 import java.net._
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.catchNonFatal
 
 trait JavaNetConfigDecoders {
-  implicit val inetAddressConfigDecoder: ConfigDecoder[InetAddress] =
-    catchNonFatal("InetAddress")(InetAddress.getByName)
+  implicit val inetAddressConfigDecoder: ConfigDecoder[String, InetAddress] =
+    ConfigDecoder.catchNonFatal[String]("InetAddress")(InetAddress.getByName)
 
-  implicit val uriConfigDecoder: ConfigDecoder[URI] =
-    catchNonFatal("URI")(new URI(_))
+  implicit val uriConfigDecoder: ConfigDecoder[String, URI] =
+    ConfigDecoder.catchNonFatal[String]("URI")(new URI(_))
 
-  implicit val urlConfigDecoder: ConfigDecoder[URL] =
-    catchNonFatal("URL")(new URL(_))
+  implicit val urlConfigDecoder: ConfigDecoder[String, URL] =
+    ConfigDecoder.catchNonFatal[String]("URL")(new URL(_))
 }

--- a/modules/core/jvm/src/main/scala/ciris/decoders/JavaNioFileConfigDecoders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/decoders/JavaNioFileConfigDecoders.scala
@@ -5,6 +5,6 @@ import java.nio.file._
 import ciris.ConfigDecoder
 
 trait JavaNioFileConfigDecoders {
-  implicit val pathConfigDecoder: ConfigDecoder[Path] =
-    ConfigDecoder.catchNonFatal("Path")(Paths.get(_))
+  implicit val pathConfigDecoder: ConfigDecoder[String, Path] =
+    ConfigDecoder.catchNonFatal[String]("Path")(Paths.get(_))
 }

--- a/modules/core/jvm/src/main/scala/ciris/decoders/JavaTimeConfigDecoders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/decoders/JavaTimeConfigDecoders.scala
@@ -3,129 +3,150 @@ package ciris.decoders
 import java.time.format.DateTimeFormatter
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.{catchNonFatal, fromOption}
 
 trait JavaTimeConfigDecoders {
   import java.time._
 
-  implicit val dayOfWeekConfigDecoder: ConfigDecoder[DayOfWeek] =
-    fromOption("DayOfWeek")(value => DayOfWeek.values.find(_.name equalsIgnoreCase value))
+  implicit val dayOfWeekConfigDecoder: ConfigDecoder[String, DayOfWeek] =
+    ConfigDecoder.fromOption[String]("DayOfWeek") { value =>
+      DayOfWeek.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val javaTimeDurationConfigDecoder: ConfigDecoder[Duration] =
-    catchNonFatal("Duration")(Duration.parse)
+  implicit val javaTimeDurationConfigDecoder: ConfigDecoder[String, Duration] =
+    ConfigDecoder.catchNonFatal[String]("Duration")(Duration.parse)
 
-  implicit val instantConfigDecoder: ConfigDecoder[Instant] =
-    catchNonFatal("Instant")(Instant.parse)
+  implicit val instantConfigDecoder: ConfigDecoder[String, Instant] =
+    ConfigDecoder.catchNonFatal[String]("Instant")(Instant.parse)
 
   implicit def localDateConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[LocalDate] = format match {
-    case null => catchNonFatal("LocalDate")(LocalDate.parse)
-    case _    => catchNonFatal("LocalDate")(LocalDate.parse(_, format))
+  ): ConfigDecoder[String, LocalDate] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("LocalDate")(LocalDate.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("LocalDate")(LocalDate.parse(_, format))
   }
 
   implicit def localDateTimeConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[LocalDateTime] = format match {
-    case null => catchNonFatal("LocalDateTime")(LocalDateTime.parse)
-    case _    => catchNonFatal("LocalDateTime")(LocalDateTime.parse(_, format))
+  ): ConfigDecoder[String, LocalDateTime] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("LocalDateTime")(LocalDateTime.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("LocalDateTime")(LocalDateTime.parse(_, format))
   }
 
   implicit def localTimeConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[LocalTime] = format match {
-    case null => catchNonFatal("LocalTime")(LocalTime.parse)
-    case _    => catchNonFatal("LocalTime")(LocalTime.parse(_, format))
+  ): ConfigDecoder[String, LocalTime] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("LocalTime")(LocalTime.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("LocalTime")(LocalTime.parse(_, format))
   }
 
-  implicit val monthConfigDecoder: ConfigDecoder[Month] =
-    fromOption("Month")(value => Month.values.find(_.name equalsIgnoreCase value))
+  implicit val monthConfigDecoder: ConfigDecoder[String, Month] =
+    ConfigDecoder.fromOption[String]("Month") { value =>
+      Month.values.find(_.name equalsIgnoreCase value)
+    }
 
   implicit def monthDayConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[MonthDay] = format match {
-    case null => catchNonFatal("MonthDay")(MonthDay.parse)
-    case _    => catchNonFatal("MonthDay")(MonthDay.parse(_, format))
+  ): ConfigDecoder[String, MonthDay] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("MonthDay")(MonthDay.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("MonthDay")(MonthDay.parse(_, format))
   }
 
   implicit def offsetDateTimeConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[OffsetDateTime] = format match {
-    case null => catchNonFatal("OffsetDateTime")(OffsetDateTime.parse)
-    case _    => catchNonFatal("OffsetDateTime")(OffsetDateTime.parse(_, format))
+  ): ConfigDecoder[String, OffsetDateTime] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("OffsetDateTime")(OffsetDateTime.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("OffsetDateTime")(OffsetDateTime.parse(_, format))
   }
 
   implicit def offsetTimeConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[OffsetTime] = format match {
-    case null => catchNonFatal("OffsetTime")(OffsetTime.parse)
-    case _    => catchNonFatal("OffsetTime")(OffsetTime.parse(_, format))
+  ): ConfigDecoder[String, OffsetTime] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("OffsetTime")(OffsetTime.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("OffsetTime")(OffsetTime.parse(_, format))
   }
 
-  implicit val periodConfigDecoder: ConfigDecoder[Period] =
-    catchNonFatal("Period")(Period.parse)
+  implicit val periodConfigDecoder: ConfigDecoder[String, Period] =
+    ConfigDecoder.catchNonFatal[String]("Period")(Period.parse)
 
   implicit def yearConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[Year] = format match {
-    case null => catchNonFatal("Year")(Year.parse)
-    case _    => catchNonFatal("Year")(Year.parse(_, format))
+  ): ConfigDecoder[String, Year] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("Year")(Year.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("Year")(Year.parse(_, format))
   }
 
   implicit def yearMonthConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[YearMonth] = format match {
-    case null => catchNonFatal("YearMonth")(YearMonth.parse)
-    case _    => catchNonFatal("YearMonth")(YearMonth.parse(_, format))
+  ): ConfigDecoder[String, YearMonth] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("YearMonth")(YearMonth.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("YearMonth")(YearMonth.parse(_, format))
   }
 
   implicit def zonedDateTimeConfigDecoder(
     implicit format: DateTimeFormatter = null
-  ): ConfigDecoder[ZonedDateTime] = format match {
-    case null => catchNonFatal("ZonedDateTime")(ZonedDateTime.parse)
-    case _    => catchNonFatal("ZonedDateTime")(ZonedDateTime.parse(_, format))
+  ): ConfigDecoder[String, ZonedDateTime] = format match {
+    case null => ConfigDecoder.catchNonFatal[String]("ZonedDateTime")(ZonedDateTime.parse)
+    case _    => ConfigDecoder.catchNonFatal[String]("ZonedDateTime")(ZonedDateTime.parse(_, format))
   }
 
-  implicit val zoneIdConfigDecoder: ConfigDecoder[ZoneId] =
-    catchNonFatal("ZoneId")(ZoneId.of)
+  implicit val zoneIdConfigDecoder: ConfigDecoder[String, ZoneId] =
+    ConfigDecoder.catchNonFatal[String]("ZoneId")(ZoneId.of)
 
-  implicit val zoneOffsetConfigDecoder: ConfigDecoder[ZoneOffset] =
-    catchNonFatal("ZoneOffset")(ZoneOffset.of)
+  implicit val zoneOffsetConfigDecoder: ConfigDecoder[String, ZoneOffset] =
+    ConfigDecoder.catchNonFatal[String]("ZoneOffset")(ZoneOffset.of)
 
   import java.time.chrono._
 
-  implicit val chronologyConfigDecoder: ConfigDecoder[Chronology] =
-    catchNonFatal("Chronology")(Chronology.of)
+  implicit val chronologyConfigDecoder: ConfigDecoder[String, Chronology] =
+    ConfigDecoder.catchNonFatal[String]("Chronology")(Chronology.of)
 
-  implicit val hijrahEraConfigDecoder: ConfigDecoder[HijrahEra] =
-    fromOption("HijrahEra")(value => HijrahEra.values.find(_.name equalsIgnoreCase value))
+  implicit val hijrahEraConfigDecoder: ConfigDecoder[String, HijrahEra] =
+    ConfigDecoder.fromOption[String]("HijrahEra") { value =>
+      HijrahEra.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val isoEraConfigDecoder: ConfigDecoder[IsoEra] =
-    fromOption("IsoEra")(value => IsoEra.values.find(_.name equalsIgnoreCase value))
+  implicit val isoEraConfigDecoder: ConfigDecoder[String, IsoEra] =
+    ConfigDecoder.fromOption[String]("IsoEra") { value =>
+      IsoEra.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val japaneseEraConfigDecoder: ConfigDecoder[JapaneseEra] =
-    fromOption("JapaneseEra")(value => JapaneseEra.values.find(_.toString equalsIgnoreCase value))
+  implicit val japaneseEraConfigDecoder: ConfigDecoder[String, JapaneseEra] =
+    ConfigDecoder.fromOption[String]("JapaneseEra") { value =>
+      JapaneseEra.values.find(_.toString equalsIgnoreCase value)
+    }
 
-  implicit val minguoEraConfigDecoder: ConfigDecoder[MinguoEra] =
-    fromOption("MinguoEra")(value => MinguoEra.values.find(_.name equalsIgnoreCase value))
+  implicit val minguoEraConfigDecoder: ConfigDecoder[String, MinguoEra] =
+    ConfigDecoder.fromOption[String]("MinguoEra") { value =>
+      MinguoEra.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val thaiBuddhistEraConfigDecoder: ConfigDecoder[ThaiBuddhistEra] =
-    fromOption("ThaiBuddhistEra")(value => ThaiBuddhistEra.values.find(_.name equalsIgnoreCase value))
+  implicit val thaiBuddhistEraConfigDecoder: ConfigDecoder[String, ThaiBuddhistEra] =
+    ConfigDecoder.fromOption[String]("ThaiBuddhistEra") { value =>
+      ThaiBuddhistEra.values.find(_.name equalsIgnoreCase value)
+    }
 
   import java.time.format._
 
-  implicit val dateTimeFormatterConfigDecoder: ConfigDecoder[DateTimeFormatter] =
-    catchNonFatal("DateTimeFormatter")(DateTimeFormatter.ofPattern)
+  implicit val dateTimeFormatterConfigDecoder: ConfigDecoder[String, DateTimeFormatter] =
+    ConfigDecoder.catchNonFatal[String]("DateTimeFormatter")(DateTimeFormatter.ofPattern)
 
-  implicit val formatStyleConfigDecoder: ConfigDecoder[FormatStyle] =
-    fromOption("FormatStyle")(value => FormatStyle.values.find(_.name equalsIgnoreCase value))
+  implicit val formatStyleConfigDecoder: ConfigDecoder[String, FormatStyle] =
+    ConfigDecoder.fromOption[String]("FormatStyle") { value =>
+      FormatStyle.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val resolverStyleConfigDecoder: ConfigDecoder[ResolverStyle] =
-    fromOption("ResolverStyle")(value => ResolverStyle.values.find(_.name equalsIgnoreCase value))
+  implicit val resolverStyleConfigDecoder: ConfigDecoder[String, ResolverStyle] =
+    ConfigDecoder.fromOption[String]("ResolverStyle") { value =>
+      ResolverStyle.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val signStyleConfigDecoder: ConfigDecoder[SignStyle] =
-    fromOption("SignStyle")(value => SignStyle.values.find(_.name equalsIgnoreCase value))
+  implicit val signStyleConfigDecoder: ConfigDecoder[String, SignStyle] =
+    ConfigDecoder.fromOption[String]("SignStyle") { value =>
+      SignStyle.values.find(_.name equalsIgnoreCase value)
+    }
 
-  implicit val textStyleConfigDecoder: ConfigDecoder[TextStyle] =
-    fromOption("TextStyle")(value => TextStyle.values.find(_.name equalsIgnoreCase value))
+  implicit val textStyleConfigDecoder: ConfigDecoder[String, TextStyle] =
+    ConfigDecoder.fromOption[String]("TextStyle") { value =>
+      TextStyle.values.find(_.name equalsIgnoreCase value)
+    }
 }

--- a/modules/core/native/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/native/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -4,23 +4,22 @@ import java.io.File
 import java.nio.charset.Charset
 
 private[ciris] trait CirisPlatformSpecific {
-  def file[Value: ConfigDecoder](
+  def file[Value](
     file: File,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  ): ConfigValue[Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] = {
     ConfigValue((file, charset))(
       ConfigSource.File,
-      ConfigDecoder[Value]
-        .mapEntryValue(modifyFileContents)
+      decoder.mapEntryValue(modifyFileContents)
     )
   }
 
-  def fileWithName[Value: ConfigDecoder](
+  def fileWithName[Value](
     name: String,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  ): ConfigValue[Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] = {
     this.file(new File(name), modifyFileContents, charset)
   }
 }

--- a/modules/core/native/src/main/scala/ciris/decoders/JavaIoConfigDecoders.scala
+++ b/modules/core/native/src/main/scala/ciris/decoders/JavaIoConfigDecoders.scala
@@ -5,6 +5,6 @@ import java.io.File
 import ciris.ConfigDecoder
 
 trait JavaIoConfigDecoders {
-  implicit val fileConfigDecoder: ConfigDecoder[File] =
-    ConfigDecoder.catchNonFatal("File")(new File(_))
+  implicit val fileConfigDecoder: ConfigDecoder[String, File] =
+    ConfigDecoder.catchNonFatal[String]("File")(new File(_))
 }

--- a/modules/core/native/src/main/scala/ciris/decoders/JavaNetConfigDecoders.scala
+++ b/modules/core/native/src/main/scala/ciris/decoders/JavaNetConfigDecoders.scala
@@ -3,12 +3,11 @@ package ciris.decoders
 import java.net._
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.catchNonFatal
 
 trait JavaNetConfigDecoders {
-  implicit val inetAddressConfigDecoder: ConfigDecoder[InetAddress] =
-    catchNonFatal("InetAddress")(InetAddress.getByName)
+  implicit val inetAddressConfigDecoder: ConfigDecoder[String, InetAddress] =
+    ConfigDecoder.catchNonFatal[String]("InetAddress")(InetAddress.getByName)
 
-  implicit val uriConfigDecoder: ConfigDecoder[URI] =
-    catchNonFatal("URI")(new URI(_))
+  implicit val uriConfigDecoder: ConfigDecoder[String, URI] =
+    ConfigDecoder.catchNonFatal[String]("URI")(new URI(_))
 }

--- a/modules/core/native/src/main/scala/ciris/decoders/JavaNioFileConfigDecoders.scala
+++ b/modules/core/native/src/main/scala/ciris/decoders/JavaNioFileConfigDecoders.scala
@@ -5,6 +5,6 @@ import java.nio.file._
 import ciris.ConfigDecoder
 
 trait JavaNioFileConfigDecoders {
-  implicit val pathConfigDecoder: ConfigDecoder[Path] =
-    ConfigDecoder.catchNonFatal("Path")(Paths.get(_))
+  implicit val pathConfigDecoder: ConfigDecoder[String, Path] =
+    ConfigDecoder.catchNonFatal[String]("Path")(Paths.get(_))
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -116,7 +116,7 @@ object ConfigValue {
     */
   def apply[Key, Value](key: Key)(
     source: ConfigSource[Key],
-    decoder: ConfigDecoder[Value]
+    decoder: ConfigDecoder[String, Value]
   ): ConfigValue[Value] = {
     ConfigValue(decoder.decode[Key, String](source.read(key)))
   }
@@ -163,7 +163,7 @@ object ConfigValue {
       */
     def apply[Key](key: Key)(
       implicit source: ConfigSource[Key],
-      decoder: ConfigDecoder[Value]
+      decoder: ConfigDecoder[String, Value]
     ): ConfigValue[Value] = {
       ConfigValue[Key, Value](key)(source, decoder)
     }

--- a/modules/core/shared/src/main/scala/ciris/decoders/CirisConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/CirisConfigDecoders.scala
@@ -3,9 +3,9 @@ package ciris.decoders
 import ciris.{ConfigDecoder, Secret}
 
 trait CirisConfigDecoders {
-  implicit def secretConfigDecoder[A](
-    implicit decoder: ConfigDecoder[A]
-  ): ConfigDecoder[Secret[A]] = {
+  implicit def secretConfigDecoder[A, B](
+    implicit decoder: ConfigDecoder[A, B]
+  ): ConfigDecoder[A, Secret[B]] = {
     decoder.map(Secret.apply)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/DerivedConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/DerivedConfigDecoders.scala
@@ -3,9 +3,11 @@ package ciris.decoders
 import ciris.{ConfigError, ConfigDecoder, ConfigEntry}
 
 trait DerivedConfigDecoders {
-  implicit def optionConfigDecoder[Value: ConfigDecoder]: ConfigDecoder[Option[Value]] =
-    new ConfigDecoder[Option[Value]] {
-      override def decode[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, Option[Value]] =
-        entry.value.fold(_ => Right(None), _ => ConfigDecoder[Value].decode(entry).right.map(Some.apply))
+  implicit def optionConfigDecoder[A, B](
+    implicit decoder: ConfigDecoder[A, B]
+  ): ConfigDecoder[A, Option[B]] =
+    new ConfigDecoder[A, Option[B]] {
+      override def decode[K, S](entry: ConfigEntry[K, S, A]): Either[ConfigError, Option[B]] =
+        entry.value.fold(_ => Right(None), _ => decoder.decode(entry).right.map(Some.apply))
     }
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/DurationConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/DurationConfigDecoders.scala
@@ -1,15 +1,14 @@
 package ciris.decoders
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.catchNonFatal
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 trait DurationConfigDecoders {
-  implicit val durationConfigDecoder: ConfigDecoder[Duration] =
-    catchNonFatal("Duration")(Duration.apply)
+  implicit val durationConfigDecoder: ConfigDecoder[String, Duration] =
+    ConfigDecoder.catchNonFatal[String]("Duration")(Duration.apply)
 
-  implicit val finiteDurationConfigDecoder: ConfigDecoder[FiniteDuration] =
+  implicit val finiteDurationConfigDecoder: ConfigDecoder[String, FiniteDuration] =
     durationConfigDecoder.mapOption("FiniteDuration") { duration =>
       Some(duration).collect { case finite: FiniteDuration => finite }
     }

--- a/modules/core/shared/src/main/scala/ciris/decoders/JavaNioCharsetConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/JavaNioCharsetConfigDecoders.scala
@@ -5,6 +5,6 @@ import java.nio.charset._
 import ciris.ConfigDecoder
 
 trait JavaNioCharsetConfigDecoders {
-  implicit val charsetConfigDecoder: ConfigDecoder[Charset] =
-    ConfigDecoder.catchNonFatal("Charset")(Charset.forName)
+  implicit val charsetConfigDecoder: ConfigDecoder[String, Charset] =
+    ConfigDecoder.catchNonFatal[String]("Charset")(Charset.forName)
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/JavaUtilConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/JavaUtilConfigDecoders.scala
@@ -4,12 +4,11 @@ import java.util.UUID
 import java.util.regex.Pattern
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.catchNonFatal
 
 trait JavaUtilConfigDecoders {
-  implicit val regexPatternConfigDecoder: ConfigDecoder[Pattern] =
-    catchNonFatal("Pattern")(Pattern.compile)
+  implicit val regexPatternConfigDecoder: ConfigDecoder[String, Pattern] =
+    ConfigDecoder.catchNonFatal[String]("Pattern")(Pattern.compile)
 
-  implicit val uuidConfigDecoder: ConfigDecoder[UUID] =
-    catchNonFatal("UUID")(UUID.fromString)
+  implicit val uuidConfigDecoder: ConfigDecoder[String, UUID] =
+    ConfigDecoder.catchNonFatal[String]("UUID")(UUID.fromString)
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/MathConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/MathConfigDecoders.scala
@@ -1,21 +1,21 @@
 package ciris.decoders
 
 import ciris.ConfigDecoder
-import java.math.{BigDecimal => JBigDecimal}
-import java.math.{BigInteger => JBigInteger}
+import java.math.{BigDecimal => JavaBigDecimal}
+import java.math.{BigInteger => JavaBigInteger}
 
 import scala.util.Try
 
 trait MathConfigDecoders {
-  implicit val bigIntConfigDecoder: ConfigDecoder[BigInt] =
-    ConfigDecoder.fromTry("BigInt")(value => Try(BigInt(value)))
+  implicit val bigIntConfigDecoder: ConfigDecoder[String, BigInt] =
+    ConfigDecoder.fromTry[String]("BigInt")(value => Try(BigInt(value)))
 
-  implicit val bigDecimalConfigDecoder: ConfigDecoder[BigDecimal] =
-    ConfigDecoder.fromTry("BigDecimal")(value => Try(BigDecimal(value)))
+  implicit val bigDecimalConfigDecoder: ConfigDecoder[String, BigDecimal] =
+    ConfigDecoder.fromTry[String]("BigDecimal")(value => Try(BigDecimal(value)))
 
-  implicit val javaBigDecimalConfigDecoder: ConfigDecoder[JBigDecimal] =
+  implicit val javaBigDecimalConfigDecoder: ConfigDecoder[String, JavaBigDecimal] =
     bigDecimalConfigDecoder.map(_.underlying)
 
-  implicit val javaBigIntegerConfigDecoder: ConfigDecoder[JBigInteger] =
+  implicit val javaBigIntegerConfigDecoder: ConfigDecoder[String, JavaBigInteger] =
     bigIntConfigDecoder.map(_.underlying)
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/PrimitiveConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/PrimitiveConfigDecoders.scala
@@ -1,41 +1,40 @@
 package ciris.decoders
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.{catchNonFatal, fromOption}
 
 trait PrimitiveConfigDecoders {
-  implicit val booleanConfigDecoder: ConfigDecoder[Boolean] =
-    catchNonFatal("Boolean")(_.toBoolean)
+  implicit val booleanConfigDecoder: ConfigDecoder[String, Boolean] =
+    ConfigDecoder.catchNonFatal[String]("Boolean")(_.toBoolean)
 
-  implicit val byteConfigDecoder: ConfigDecoder[Byte] =
-    catchNonFatal("Byte")(_.toByte)
+  implicit val byteConfigDecoder: ConfigDecoder[String, Byte] =
+    ConfigDecoder.catchNonFatal[String]("Byte")(_.toByte)
 
-  implicit val charConfigDecoder: ConfigDecoder[Char] =
-    fromOption("Char") { value =>
+  implicit val charConfigDecoder: ConfigDecoder[String, Char] =
+    ConfigDecoder.fromOption[String]("Char") { value =>
       if (value.length == 1) Some(value.head) else None
     }
 
-  implicit val doubleConfigDecoder: ConfigDecoder[Double] =
-    catchNonFatal("Double") {
+  implicit val doubleConfigDecoder: ConfigDecoder[String, Double] =
+    ConfigDecoder.catchNonFatal[String]("Double") {
       case s if s.lastOption.exists(_ == '%') => s.init.toDouble / 100d
       case s => s.toDouble
     }
 
-  implicit val floatConfigDecoder: ConfigDecoder[Float] =
-    catchNonFatal("Float") {
+  implicit val floatConfigDecoder: ConfigDecoder[String, Float] =
+    ConfigDecoder.catchNonFatal[String]("Float") {
       case s if s.lastOption.exists(_ == '%') => s.init.toFloat / 100f
       case s => s.toFloat
     }
 
-  implicit val intConfigDecoder: ConfigDecoder[Int] =
-    catchNonFatal("Int")(_.toInt)
+  implicit val intConfigDecoder: ConfigDecoder[String, Int] =
+    ConfigDecoder.catchNonFatal[String]("Int")(_.toInt)
 
-  implicit val longConfigDecoder: ConfigDecoder[Long] =
-    catchNonFatal("Long")(_.toLong)
+  implicit val longConfigDecoder: ConfigDecoder[String, Long] =
+    ConfigDecoder.catchNonFatal[String]("Long")(_.toLong)
 
-  implicit val shortConfigDecoder: ConfigDecoder[Short] =
-    catchNonFatal("Short")(_.toShort)
+  implicit val shortConfigDecoder: ConfigDecoder[String, Short] =
+    ConfigDecoder.catchNonFatal[String]("Short")(_.toShort)
 
-  implicit val stringConfigDecoder: ConfigDecoder[String] =
+  implicit def identityConfigDecoder[A]: ConfigDecoder[A, A] =
     ConfigDecoder.identity
 }

--- a/modules/core/shared/src/main/scala/ciris/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/package.scala
@@ -18,8 +18,8 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * res0: ciris.ConfigValue[Int] = ConfigValue(Left(MissingKey(key, Environment)))
     * }}}
     */
-  def env[Value: ConfigDecoder](key: String): ConfigValue[Value] =
-    ConfigValue(key)(ConfigSource.Environment, ConfigDecoder[Value])
+  def env[Value](key: String)(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] =
+    ConfigValue(key)(ConfigSource.Environment, decoder)
 
   /**
     * Reads the system property with the specified key name,
@@ -34,8 +34,8 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * res0: ciris.ConfigValue[Int] = ConfigValue(Left(MissingKey(key, Property)))
     * }}}
     */
-  def prop[Value: ConfigDecoder](key: String): ConfigValue[Value] =
-    ConfigValue(key)(ConfigSource.Properties, ConfigDecoder[Value])
+  def prop[Value](key: String)(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] =
+    ConfigValue(key)(ConfigSource.Properties, decoder)
 
   /**
     * Reads the command-line argument with the specified index,
@@ -57,8 +57,8 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * res2: ciris.ConfigValue[Int] = ConfigValue(Left(WrongType(0, a, Int, Argument, Some(java.lang.NumberFormatException: For input string: "a"))))
     * }}}
     */
-  def arg[Value: ConfigDecoder](args: IndexedSeq[String])(index: Int): ConfigValue[Value] =
-    ConfigValue(index)(ConfigSource.byIndex(ConfigKeyType.Argument)(args), ConfigDecoder[Value])
+  def arg[Value](args: IndexedSeq[String])(index: Int)(implicit decoder: ConfigDecoder[String, Value]): ConfigValue[Value] =
+    ConfigValue(index)(ConfigSource.byIndex(ConfigKeyType.Argument)(args), decoder)
 
   /**
     * Reads from an implicit source, and tries to convert the value

--- a/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/decoders/EnumeratumConfigDecoders.scala
+++ b/modules/enumeratum/shared/src/main/scala/ciris/enumeratum/decoders/EnumeratumConfigDecoders.scala
@@ -8,13 +8,12 @@ import ciris.{ConfigError, ConfigDecoder, ConfigEntry}
 import scala.reflect.ClassTag
 
 trait EnumeratumConfigDecoders {
-  private def fromOption[
-    From: ConfigDecoder,
-    To: ClassTag
-  ](f: From => Option[To]): ConfigDecoder[To] =
-    new ConfigDecoder[To] {
-      override def decode[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, To] =
-        ConfigDecoder[From].decode(entry).right.flatMap { value =>
+  private def fromOption[From, To: ClassTag](f: From => Option[To])(
+    implicit decoder: ConfigDecoder[String, From]
+  ): ConfigDecoder[String, To] =
+    new ConfigDecoder[String, To] {
+      override def decode[K, S](entry: ConfigEntry[K, S, String]): Either[ConfigError, To] =
+        decoder.decode(entry).right.flatMap { value =>
           f(value) match {
             case Some(to) => Right(to)
             case None =>
@@ -25,23 +24,23 @@ trait EnumeratumConfigDecoders {
     }
 
   implicit def byteEnumEntryConfigDecoder[A <: ByteEnumEntry: ClassTag](
-    implicit enum: ByteEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: ByteEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 
   implicit def charEnumEntryConfigDecoder[A <: CharEnumEntry: ClassTag](
-    implicit enum: CharEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: CharEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 
   implicit def enumEntryConfigDecoder[A <: EnumEntry: ClassTag](
-    implicit enum: Enum[A]): ConfigDecoder[A] = fromOption(enum.withNameOption)
+    implicit enum: Enum[A]): ConfigDecoder[String, A] = fromOption(enum.withNameOption)
 
   implicit def intEnumEntryConfigDecoder[A <: IntEnumEntry: ClassTag](
-    implicit enum: IntEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: IntEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 
   implicit def longEnumEntryConfigDecoder[A <: LongEnumEntry: ClassTag](
-    implicit enum: LongEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: LongEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 
   implicit def shortEnumEntryConfigDecoder[A <: ShortEnumEntry: ClassTag](
-    implicit enum: ShortEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: ShortEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 
   implicit def stringEnumEntryConfigDecoder[A <: StringEnumEntry: ClassTag](
-    implicit enum: StringEnum[A]): ConfigDecoder[A] = fromOption(enum.withValueOpt)
+    implicit enum: StringEnum[A]): ConfigDecoder[String, A] = fromOption(enum.withValueOpt)
 }

--- a/modules/generic/shared/src/main/scala/ciris/generic/decoders/GenericConfigDecoders.scala
+++ b/modules/generic/shared/src/main/scala/ciris/generic/decoders/GenericConfigDecoders.scala
@@ -4,21 +4,23 @@ import ciris.{ConfigError, ConfigDecoder, ConfigEntry}
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HNil, Inl, Inr, Lazy}
 
 trait GenericConfigDecoders {
-  implicit val cNilConfigDecoder: ConfigDecoder[CNil] =
-    new ConfigDecoder[CNil] {
-      override def decode[Key, S](entry: ConfigEntry[Key, S, String]): Either[ConfigError, CNil] =
-        Left(ConfigError(
-          s"Could not find any valid coproduct choice while decoding ${entry.keyType.name} [${entry.key}]"))
+  implicit def cNilConfigDecoder[A]: ConfigDecoder[A, CNil] =
+    new ConfigDecoder[A, CNil] {
+      override def decode[K, S](entry: ConfigEntry[K, S, A]): Either[ConfigError, CNil] =
+        Left(ConfigError {
+          s"Could not find any valid coproduct choice while decoding ${entry.keyType.name} [${entry.key}]"
+        })
     }
 
-  implicit def coproductConfigDecoder[A, B <: Coproduct](
-    implicit decodeA: Lazy[ConfigDecoder[A]],
-    decodeB: ConfigDecoder[B]
-  ): ConfigDecoder[A :+: B] =
-    new ConfigDecoder[A :+: B] {
-      override def decode[Key, S](
-        entry: ConfigEntry[Key, S, String]): Either[ConfigError, A :+: B] =
-        decodeA.value.decode(entry) match {
+  implicit def coproductConfigDecoder[A, B <: Coproduct, C](
+    implicit decodeC: Lazy[ConfigDecoder[A, C]],
+    decodeB: ConfigDecoder[A, B]
+  ): ConfigDecoder[A, C :+: B] =
+    new ConfigDecoder[A, C :+: B] {
+      override def decode[K, S](
+        entry: ConfigEntry[K, S, A]
+      ): Either[ConfigError, C :+: B] =
+        decodeC.value.decode(entry) match {
           case Right(a) => Right(Inl(a))
           case Left(aError) =>
             decodeB.decode(entry) match {
@@ -28,16 +30,16 @@ trait GenericConfigDecoders {
         }
     }
 
-  implicit def unaryHListConfigDecoder[A](
-    implicit decodeA: Lazy[ConfigDecoder[A]]
-  ): ConfigDecoder[A :: HNil] = {
-    decodeA.value.map(_ :: HNil)
+  implicit def unaryHListConfigDecoder[A, B](
+    implicit decodeB: Lazy[ConfigDecoder[A, B]]
+  ): ConfigDecoder[A, B :: HNil] = {
+    decodeB.value.map(_ :: HNil)
   }
 
-  implicit def genericConfigDecoder[A, B](
-    implicit gen: Generic.Aux[A, B],
-    decodeB: Lazy[ConfigDecoder[B]]
-  ): ConfigDecoder[A] = {
+  implicit def genericConfigDecoder[A, B, C](
+    implicit gen: Generic.Aux[C, B],
+    decodeB: Lazy[ConfigDecoder[A, B]]
+  ): ConfigDecoder[A, C] = {
     decodeB.value.map(gen.from)
   }
 }

--- a/modules/refined/js/src/main/scala/ciris/refined/decoders/RefinedConfigDecoders.scala
+++ b/modules/refined/js/src/main/scala/ciris/refined/decoders/RefinedConfigDecoders.scala
@@ -6,12 +6,12 @@ import eu.timepit.refined.api.{RefType, Validate}
 import scala.reflect.ClassTag
 
 trait RefinedConfigDecoders {
-  implicit def refTypeConfigDecoder[F[_, _], T, P](
-    implicit decoder: ConfigDecoder[T],
+  implicit def refTypeConfigDecoder[F[_, _], A, T, P](
+    implicit decoder: ConfigDecoder[A, T],
     refType: RefType[F],
     validate: Validate[T, P],
     classTag: ClassTag[F[T, P]]
-  ): ConfigDecoder[F[T, P]] = {
+  ): ConfigDecoder[A, F[T, P]] = {
     val typeName = classTag.runtimeClass.getSimpleName
     decoder.mapEither(typeName)(refType.refine[P].apply(_))
   }

--- a/modules/refined/jvm/src/main/scala/ciris/refined/decoders/RefinedConfigDecoders.scala
+++ b/modules/refined/jvm/src/main/scala/ciris/refined/decoders/RefinedConfigDecoders.scala
@@ -6,12 +6,12 @@ import eu.timepit.refined.api.{RefType, Validate}
 import scala.reflect.runtime.universe.WeakTypeTag
 
 trait RefinedConfigDecoders {
-  implicit def refTypeConfigDecoder[F[_, _], T, P](
-    implicit decoder: ConfigDecoder[T],
+  implicit def refTypeConfigDecoder[F[_, _], A, T, P](
+    implicit decoder: ConfigDecoder[A, T],
     refType: RefType[F],
     validate: Validate[T, P],
     typeTag: WeakTypeTag[F[T, P]]
-  ): ConfigDecoder[F[T, P]] = {
+  ): ConfigDecoder[A, F[T, P]] = {
     val typeName = typeTag.tpe.toString
     decoder.mapEither(typeName)(refType.refine[P].apply(_))
   }

--- a/modules/spire/shared/src/main/scala/ciris/spire/decoders/SpireConfigDecoders.scala
+++ b/modules/spire/shared/src/main/scala/ciris/spire/decoders/SpireConfigDecoders.scala
@@ -6,69 +6,69 @@ import spire.math._
 import scala.util.{Success, Try}
 
 trait SpireConfigDecoders {
-  implicit val algebraicConfigDecoder: ConfigDecoder[Algebraic] =
-    ConfigDecoder.catchNonFatal("Algebraic")(Algebraic.apply)
+  implicit val algebraicConfigDecoder: ConfigDecoder[String, Algebraic] =
+    ConfigDecoder.catchNonFatal[String]("Algebraic")(Algebraic.apply)
 
-  implicit val intervalRationalConfigDecoder: ConfigDecoder[Interval[Rational]] =
-    ConfigDecoder.catchNonFatal("Interval[Rational]")(Interval.apply)
+  implicit val intervalRationalConfigDecoder: ConfigDecoder[String, Interval[Rational]] =
+    ConfigDecoder.catchNonFatal[String]("Interval[Rational]")(Interval.apply)
 
-  implicit val naturalConfigDecoder: ConfigDecoder[Natural] =
-    ConfigDecoder.fromTryOption("Natural") { value =>
+  implicit val naturalConfigDecoder: ConfigDecoder[String, Natural] =
+    ConfigDecoder.fromTryOption[String]("Natural") { value =>
       if (value.forall(_.isDigit))
         Try(Some(Natural(value)))
       else
         Success(None)
     }
 
-  implicit val numberConfigDecoder: ConfigDecoder[Number] =
-    ConfigDecoder.catchNonFatal("Number")(Number.apply)
+  implicit val numberConfigDecoder: ConfigDecoder[String, Number] =
+    ConfigDecoder.catchNonFatal[String]("Number")(Number.apply)
 
-  implicit val polynomialRationalConfigDecoder: ConfigDecoder[Polynomial[Rational]] =
-    ConfigDecoder.catchNonFatal("Polynomial[Rational]")(Polynomial.apply)
+  implicit val polynomialRationalConfigDecoder: ConfigDecoder[String, Polynomial[Rational]] =
+    ConfigDecoder.catchNonFatal[String]("Polynomial[Rational]")(Polynomial.apply)
 
-  implicit val rationalConfigDecoder: ConfigDecoder[Rational] =
-    ConfigDecoder.catchNonFatal("Rational")(Rational.apply)
+  implicit val rationalConfigDecoder: ConfigDecoder[String, Rational] =
+    ConfigDecoder.catchNonFatal[String]("Rational")(Rational.apply)
 
-  implicit val realConfigDecoder: ConfigDecoder[Real] =
-    ConfigDecoder.catchNonFatal("Real")(Real.apply)
+  implicit val realConfigDecoder: ConfigDecoder[String, Real] =
+    ConfigDecoder.catchNonFatal[String]("Real")(Real.apply)
 
-  implicit def safeLongConfigDecoder(
-    implicit decoder: ConfigDecoder[BigInt]
-  ): ConfigDecoder[SafeLong] =
+  implicit def safeLongConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, BigInt]
+  ): ConfigDecoder[A, SafeLong] =
     decoder.map(SafeLong.apply)
 
-  implicit def trileanConfigDecoder(
-    implicit decoder: ConfigDecoder[Option[Boolean]]
-  ): ConfigDecoder[Trilean] =
+  implicit def trileanConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, Option[Boolean]]
+  ): ConfigDecoder[A, Trilean] =
     decoder.map(Trilean.apply)
 
-  implicit def ubyteConfigDecoder(
-    implicit decoder: ConfigDecoder[Int]
-  ): ConfigDecoder[UByte] =
+  implicit def ubyteConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, Int]
+  ): ConfigDecoder[A, UByte] =
     decoder.collect("UByte") {
       case int if UByte.MinValue.toInt <= int && int <= UByte.MaxValue.toInt =>
         UByte(int)
     }
 
-  implicit def uintConfigDecoder(
-    implicit decoder: ConfigDecoder[Long]
-  ): ConfigDecoder[UInt] =
+  implicit def uintConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, Long]
+  ): ConfigDecoder[A, UInt] =
     decoder.collect("UInt") {
       case long if UInt.MinValue.toLong <= long && long <= UInt.MaxValue.toLong =>
         UInt(long)
     }
 
-  implicit def ulongConfigDecoder(
-    implicit decoder: ConfigDecoder[BigInt]
-  ): ConfigDecoder[ULong] =
+  implicit def ulongConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, BigInt]
+  ): ConfigDecoder[A, ULong] =
     decoder.collect("ULong") {
       case bigInt if ULong.MinValue.toBigInt <= bigInt && bigInt <= ULong.MaxValue.toBigInt =>
         ULong.fromBigInt(bigInt)
     }
 
-  implicit def ushortConfigDecoder(
-    implicit decoder: ConfigDecoder[Int]
-  ): ConfigDecoder[UShort] =
+  implicit def ushortConfigDecoder[A](
+    implicit decoder: ConfigDecoder[A, Int]
+  ): ConfigDecoder[A, UShort] =
     decoder.collect("UShort") {
       case int if UShort.MinValue.toInt <= int && int <= UShort.MaxValue.toInt =>
         UShort(int)

--- a/modules/squants/shared/src/main/scala/ciris/squants/decoders/SquantsConfigDecoders.scala
+++ b/modules/squants/shared/src/main/scala/ciris/squants/decoders/SquantsConfigDecoders.scala
@@ -1,205 +1,204 @@
 package ciris.squants.decoders
 
 import ciris.ConfigDecoder
-import ciris.ConfigDecoder.fromTry
 
 import scala.util.Try
 
 trait SquantsConfigDecoders {
   import squants.electro._
 
-  implicit val capacitanceConfigDecoder: ConfigDecoder[Capacitance] =
-    fromTry("Capacitance")(Capacitance.apply)
+  implicit val capacitanceConfigDecoder: ConfigDecoder[String, Capacitance] =
+    ConfigDecoder.fromTry[String]("Capacitance")(Capacitance.apply)
 
-  implicit val conductivityConfigDecoder: ConfigDecoder[Conductivity] =
-    fromTry("Conductivity")(Conductivity.apply)
+  implicit val conductivityConfigDecoder: ConfigDecoder[String, Conductivity] =
+    ConfigDecoder.fromTry[String]("Conductivity")(Conductivity.apply)
 
-  implicit val electricalConductanceConfigDecoder: ConfigDecoder[ElectricalConductance] =
-    fromTry("ElectricalConductance")(ElectricalConductance.apply)
+  implicit val electricalConductanceConfigDecoder: ConfigDecoder[String, ElectricalConductance] =
+    ConfigDecoder.fromTry[String]("ElectricalConductance")(ElectricalConductance.apply)
 
-  implicit val electricalResistanceConfigDecoder: ConfigDecoder[ElectricalResistance] =
-    fromTry("ElectricalResistance")(ElectricalResistance.apply)
+  implicit val electricalResistanceConfigDecoder: ConfigDecoder[String, ElectricalResistance] =
+    ConfigDecoder.fromTry[String]("ElectricalResistance")(ElectricalResistance.apply)
 
-  implicit val electricChargeConfigDecoder: ConfigDecoder[ElectricCharge] =
-    fromTry("ElectricCharge")(ElectricCharge.apply)
+  implicit val electricChargeConfigDecoder: ConfigDecoder[String, ElectricCharge] =
+    ConfigDecoder.fromTry[String]("ElectricCharge")(ElectricCharge.apply)
 
-  implicit val electricCurrentConfigDecoder: ConfigDecoder[ElectricCurrent] =
-    fromTry("ElectricCurrent")(ElectricCurrent.apply)
+  implicit val electricCurrentConfigDecoder: ConfigDecoder[String, ElectricCurrent] =
+    ConfigDecoder.fromTry[String]("ElectricCurrent")(ElectricCurrent.apply)
 
-  implicit val electricPotentialConfigDecoder: ConfigDecoder[ElectricPotential] =
-    fromTry("ElectricPotential")(ElectricPotential.apply)
+  implicit val electricPotentialConfigDecoder: ConfigDecoder[String, ElectricPotential] =
+    ConfigDecoder.fromTry[String]("ElectricPotential")(ElectricPotential.apply)
 
-  implicit val inductanceConfigDecoder: ConfigDecoder[Inductance] =
-    fromTry("Inductance")(Inductance.apply)
+  implicit val inductanceConfigDecoder: ConfigDecoder[String, Inductance] =
+    ConfigDecoder.fromTry[String]("Inductance")(Inductance.apply)
 
-  implicit val magneticFluxConfigDecoder: ConfigDecoder[MagneticFlux] =
-    fromTry("MagneticFlux")(MagneticFlux.apply)
+  implicit val magneticFluxConfigDecoder: ConfigDecoder[String, MagneticFlux] =
+    ConfigDecoder.fromTry[String]("MagneticFlux")(MagneticFlux.apply)
 
-  implicit val magneticFluxDensityConfigDecoder: ConfigDecoder[MagneticFluxDensity] =
-    fromTry("MagneticFluxDensity")(MagneticFluxDensity.apply)
+  implicit val magneticFluxDensityConfigDecoder: ConfigDecoder[String, MagneticFluxDensity] =
+    ConfigDecoder.fromTry[String]("MagneticFluxDensity")(MagneticFluxDensity.apply)
 
-  implicit val resistivityConfigDecoder: ConfigDecoder[Resistivity] =
-    fromTry("Resistivity")(Resistivity.apply)
+  implicit val resistivityConfigDecoder: ConfigDecoder[String, Resistivity] =
+    ConfigDecoder.fromTry[String]("Resistivity")(Resistivity.apply)
 
   import squants.energy._
 
-  implicit val energyConfigDecoder: ConfigDecoder[Energy] =
-    fromTry("Energy")(Energy.apply)
+  implicit val energyConfigDecoder: ConfigDecoder[String, Energy] =
+    ConfigDecoder.fromTry[String]("Energy")(Energy.apply)
 
-  implicit val energyDensityConfigDecoder: ConfigDecoder[EnergyDensity] =
-    fromTry("EnergyDensity")(EnergyDensity.apply)
+  implicit val energyDensityConfigDecoder: ConfigDecoder[String, EnergyDensity] =
+    ConfigDecoder.fromTry[String]("EnergyDensity")(EnergyDensity.apply)
 
-  implicit val powerConfigDecoder: ConfigDecoder[Power] =
-    fromTry("Power")(Power.apply)
+  implicit val powerConfigDecoder: ConfigDecoder[String, Power] =
+    ConfigDecoder.fromTry[String]("Power")(Power.apply)
 
-  implicit val powerRampConfigDecoder: ConfigDecoder[PowerRamp] =
-    fromTry("PowerRamp")(PowerRamp.apply)
+  implicit val powerRampConfigDecoder: ConfigDecoder[String, PowerRamp] =
+    ConfigDecoder.fromTry[String]("PowerRamp")(PowerRamp.apply)
 
-  implicit val specificEnergyConfigDecoder: ConfigDecoder[SpecificEnergy] =
-    fromTry("SpecificEnergy")(SpecificEnergy.apply)
+  implicit val specificEnergyConfigDecoder: ConfigDecoder[String, SpecificEnergy] =
+    ConfigDecoder.fromTry[String]("SpecificEnergy")(SpecificEnergy.apply)
 
   import squants.information._
 
-  implicit val dataRateConfigDecoder: ConfigDecoder[DataRate] =
-    fromTry("DataRate")(DataRate.apply)
+  implicit val dataRateConfigDecoder: ConfigDecoder[String, DataRate] =
+    ConfigDecoder.fromTry[String]("DataRate")(DataRate.apply)
 
-  implicit val informationConfigDecoder: ConfigDecoder[Information] =
-    fromTry("Information")(Information.apply)
+  implicit val informationConfigDecoder: ConfigDecoder[String, Information] =
+    ConfigDecoder.fromTry[String]("Information")(Information.apply)
 
   import squants.market._
 
-  implicit val moneyDensityConfigDecoder: ConfigDecoder[Money] =
-    fromTry("Money")(Money.apply)
+  implicit val moneyDensityConfigDecoder: ConfigDecoder[String, Money] =
+    ConfigDecoder.fromTry[String]("Money")(Money.apply)
 
   import squants.mass._
 
-  implicit val areaDensityConfigDecoder: ConfigDecoder[AreaDensity] =
-    fromTry("AreaDensity")(AreaDensity.apply)
+  implicit val areaDensityConfigDecoder: ConfigDecoder[String, AreaDensity] =
+    ConfigDecoder.fromTry[String]("AreaDensity")(AreaDensity.apply)
 
-  implicit val chemicalAmountConfigDecoder: ConfigDecoder[ChemicalAmount] =
-    fromTry("ChemicalAmount")(ChemicalAmount.apply)
+  implicit val chemicalAmountConfigDecoder: ConfigDecoder[String, ChemicalAmount] =
+    ConfigDecoder.fromTry[String]("ChemicalAmount")(ChemicalAmount.apply)
 
-  implicit val densityConfigDecoder: ConfigDecoder[Density] =
-    fromTry("Density")(Density.apply)
+  implicit val densityConfigDecoder: ConfigDecoder[String, Density] =
+    ConfigDecoder.fromTry[String]("Density")(Density.apply)
 
-  implicit val massConfigDecoder: ConfigDecoder[Mass] =
-    fromTry("Mass")(Mass.apply)
+  implicit val massConfigDecoder: ConfigDecoder[String, Mass] =
+    ConfigDecoder.fromTry[String]("Mass")(Mass.apply)
 
-  implicit val momentOfInertiaConfigDecoder: ConfigDecoder[MomentOfInertia] =
-    fromTry("MomentOfInertia")(MomentOfInertia.apply)
+  implicit val momentOfInertiaConfigDecoder: ConfigDecoder[String, MomentOfInertia] =
+    ConfigDecoder.fromTry[String]("MomentOfInertia")(MomentOfInertia.apply)
 
   import squants.motion._
 
-  implicit val accelerationConfigDecoder: ConfigDecoder[Acceleration] =
-    fromTry("Acceleration")(Acceleration.apply)
+  implicit val accelerationConfigDecoder: ConfigDecoder[String, Acceleration] =
+    ConfigDecoder.fromTry[String]("Acceleration")(Acceleration.apply)
 
-  implicit val angularAccelerationConfigDecoder: ConfigDecoder[AngularAcceleration] =
-    fromTry("AngularAcceleration")(AngularAcceleration.apply)
+  implicit val angularAccelerationConfigDecoder: ConfigDecoder[String, AngularAcceleration] =
+    ConfigDecoder.fromTry[String]("AngularAcceleration")(AngularAcceleration.apply)
 
-  implicit val angularVelocityConfigDecoder: ConfigDecoder[AngularVelocity] =
-    fromTry("AngularVelocity")(AngularVelocity.apply)
+  implicit val angularVelocityConfigDecoder: ConfigDecoder[String, AngularVelocity] =
+    ConfigDecoder.fromTry[String]("AngularVelocity")(AngularVelocity.apply)
 
-  implicit val forceConfigDecoder: ConfigDecoder[Force] =
-    fromTry("Force")(Force.apply)
+  implicit val forceConfigDecoder: ConfigDecoder[String, Force] =
+    ConfigDecoder.fromTry[String]("Force")(Force.apply)
 
-  implicit val jerkConfigDecoder: ConfigDecoder[Jerk] =
-    fromTry("Jerk")(Jerk.apply)
+  implicit val jerkConfigDecoder: ConfigDecoder[String, Jerk] =
+    ConfigDecoder.fromTry[String]("Jerk")(Jerk.apply)
 
-  implicit val massFlowConfigDecoder: ConfigDecoder[MassFlow] =
-    fromTry("MassFlow")(MassFlow.apply)
+  implicit val massFlowConfigDecoder: ConfigDecoder[String, MassFlow] =
+    ConfigDecoder.fromTry[String]("MassFlow")(MassFlow.apply)
 
-  implicit val momentumConfigDecoder: ConfigDecoder[Momentum] =
-    fromTry("Momentum")(Momentum.apply)
+  implicit val momentumConfigDecoder: ConfigDecoder[String, Momentum] =
+    ConfigDecoder.fromTry[String]("Momentum")(Momentum.apply)
 
-  implicit val pressureConfigDecoder: ConfigDecoder[Pressure] =
-    fromTry("Pressure")(Pressure.apply)
+  implicit val pressureConfigDecoder: ConfigDecoder[String, Pressure] =
+    ConfigDecoder.fromTry[String]("Pressure")(Pressure.apply)
 
-  implicit val pressureChangeConfigDecoder: ConfigDecoder[PressureChange] =
-    fromTry("PressureChange")(PressureChange.apply)
+  implicit val pressureChangeConfigDecoder: ConfigDecoder[String, PressureChange] =
+    ConfigDecoder.fromTry[String]("PressureChange")(PressureChange.apply)
 
-  implicit val torqueConfigDecoder: ConfigDecoder[Torque] =
-    fromTry("Torque")(Torque.apply)
+  implicit val torqueConfigDecoder: ConfigDecoder[String, Torque] =
+    ConfigDecoder.fromTry[String]("Torque")(Torque.apply)
 
-  implicit val velocityConfigDecoder: ConfigDecoder[Velocity] =
-    fromTry("Velocity")(Velocity.apply)
+  implicit val velocityConfigDecoder: ConfigDecoder[String, Velocity] =
+    ConfigDecoder.fromTry[String]("Velocity")(Velocity.apply)
 
-  implicit val volumeFlowConfigDecoder: ConfigDecoder[VolumeFlow] =
-    fromTry("VolumeFlow")(VolumeFlow.apply)
+  implicit val volumeFlowConfigDecoder: ConfigDecoder[String, VolumeFlow] =
+    ConfigDecoder.fromTry[String]("VolumeFlow")(VolumeFlow.apply)
 
-  implicit val yankConfigDecoder: ConfigDecoder[Yank] =
-    fromTry("Yank")(Yank.apply)
+  implicit val yankConfigDecoder: ConfigDecoder[String, Yank] =
+    ConfigDecoder.fromTry[String]("Yank")(Yank.apply)
 
   import squants.photo._
 
-  implicit val illuminanceConfigDecoder: ConfigDecoder[Illuminance] =
-    fromTry("Illuminance")(Illuminance.apply)
+  implicit val illuminanceConfigDecoder: ConfigDecoder[String, Illuminance] =
+    ConfigDecoder.fromTry[String]("Illuminance")(Illuminance.apply)
 
-  implicit val luminanceConfigDecoder: ConfigDecoder[Luminance] =
-    fromTry("Luminance")(Luminance.apply)
+  implicit val luminanceConfigDecoder: ConfigDecoder[String, Luminance] =
+    ConfigDecoder.fromTry[String]("Luminance")(Luminance.apply)
 
-  implicit val luminousEnergyConfigDecoder: ConfigDecoder[LuminousEnergy] =
-    fromTry("LuminousEnergy")(LuminousEnergy.apply)
+  implicit val luminousEnergyConfigDecoder: ConfigDecoder[String, LuminousEnergy] =
+    ConfigDecoder.fromTry[String]("LuminousEnergy")(LuminousEnergy.apply)
 
-  implicit val luminousExposureConfigDecoder: ConfigDecoder[LuminousExposure] =
-    fromTry("LuminousExposure")(LuminousExposure.apply)
+  implicit val luminousExposureConfigDecoder: ConfigDecoder[String, LuminousExposure] =
+    ConfigDecoder.fromTry[String]("LuminousExposure")(LuminousExposure.apply)
 
-  implicit val luminousFluxConfigDecoder: ConfigDecoder[LuminousFlux] =
-    fromTry("LuminousFlux")(LuminousFlux.apply)
+  implicit val luminousFluxConfigDecoder: ConfigDecoder[String, LuminousFlux] =
+    ConfigDecoder.fromTry[String]("LuminousFlux")(LuminousFlux.apply)
 
-  implicit val luminousIntensityConfigDecoder: ConfigDecoder[LuminousIntensity] =
-    fromTry("LuminousIntensity")(LuminousIntensity.apply)
+  implicit val luminousIntensityConfigDecoder: ConfigDecoder[String, LuminousIntensity] =
+    ConfigDecoder.fromTry[String]("LuminousIntensity")(LuminousIntensity.apply)
 
   import squants.radio._
 
-  implicit val irradianceConfigDecoder: ConfigDecoder[Irradiance] =
-    fromTry("Irradiance")(Irradiance.apply)
+  implicit val irradianceConfigDecoder: ConfigDecoder[String, Irradiance] =
+    ConfigDecoder.fromTry[String]("Irradiance")(Irradiance.apply)
 
-  implicit val radianceConfigDecoder: ConfigDecoder[Radiance] =
-    fromTry("Radiance")(Radiance.apply)
+  implicit val radianceConfigDecoder: ConfigDecoder[String, Radiance] =
+    ConfigDecoder.fromTry[String]("Radiance")(Radiance.apply)
 
-  implicit val radiantIntensityConfigDecoder: ConfigDecoder[RadiantIntensity] =
-    fromTry("RadiantIntensity")(RadiantIntensity.apply)
+  implicit val radiantIntensityConfigDecoder: ConfigDecoder[String, RadiantIntensity] =
+    ConfigDecoder.fromTry[String]("RadiantIntensity")(RadiantIntensity.apply)
 
-  implicit val spectralIntensityConfigDecoder: ConfigDecoder[SpectralIntensity] =
-    fromTry("SpectralIntensity")(SpectralIntensity.apply)
+  implicit val spectralIntensityConfigDecoder: ConfigDecoder[String, SpectralIntensity] =
+    ConfigDecoder.fromTry[String]("SpectralIntensity")(SpectralIntensity.apply)
 
-  implicit val spectralIrradianceConfigDecoder: ConfigDecoder[SpectralIrradiance] =
-    fromTry("SpectralIrradiance")(SpectralIrradiance.apply)
+  implicit val spectralIrradianceConfigDecoder: ConfigDecoder[String, SpectralIrradiance] =
+    ConfigDecoder.fromTry[String]("SpectralIrradiance")(SpectralIrradiance.apply)
 
-  implicit val spectralPowerConfigDecoder: ConfigDecoder[SpectralPower] =
-    fromTry("SpectralPower")(SpectralPower.apply)
+  implicit val spectralPowerConfigDecoder: ConfigDecoder[String, SpectralPower] =
+    ConfigDecoder.fromTry[String]("SpectralPower")(SpectralPower.apply)
 
   import squants.space._
 
-  implicit val angleConfigDecoder: ConfigDecoder[Angle] =
-    fromTry("Angle")(Angle.apply)
+  implicit val angleConfigDecoder: ConfigDecoder[String, Angle] =
+    ConfigDecoder.fromTry[String]("Angle")(Angle.apply)
 
-  implicit val areaConfigDecoder: ConfigDecoder[Area] =
-    fromTry("Area")(Area.apply)
+  implicit val areaConfigDecoder: ConfigDecoder[String, Area] =
+    ConfigDecoder.fromTry[String]("Area")(Area.apply)
 
-  implicit val lengthConfigDecoder: ConfigDecoder[Length] =
-    fromTry("Length")(Length.apply)
+  implicit val lengthConfigDecoder: ConfigDecoder[String, Length] =
+    ConfigDecoder.fromTry[String]("Length")(Length.apply)
 
-  implicit val solidAngleConfigDecoder: ConfigDecoder[SolidAngle] =
-    fromTry("SolidAngle")(SolidAngle.apply)
+  implicit val solidAngleConfigDecoder: ConfigDecoder[String, SolidAngle] =
+    ConfigDecoder.fromTry[String]("SolidAngle")(SolidAngle.apply)
 
-  implicit val volumeConfigDecoder: ConfigDecoder[Volume] =
-    fromTry("Volume")(Volume.apply)
+  implicit val volumeConfigDecoder: ConfigDecoder[String, Volume] =
+    ConfigDecoder.fromTry[String]("Volume")(Volume.apply)
 
   import squants.thermal._
 
   // https://github.com/typelevel/squants/issues/261
-  implicit val temperatureConfigDecoder: ConfigDecoder[Temperature] =
-    fromTry("Temperature")(value => Try(Temperature(value)).flatten)
+  implicit val temperatureConfigDecoder: ConfigDecoder[String, Temperature] =
+    ConfigDecoder.fromTry[String]("Temperature")(value => Try(Temperature(value)).flatten)
 
-  implicit val thermalCapacityConfigDecoder: ConfigDecoder[ThermalCapacity] =
-    fromTry("ThermalCapacity")(ThermalCapacity.apply)
+  implicit val thermalCapacityConfigDecoder: ConfigDecoder[String, ThermalCapacity] =
+    ConfigDecoder.fromTry[String]("ThermalCapacity")(ThermalCapacity.apply)
 
   import squants.time._
 
-  implicit val frequencyConfigDecoder: ConfigDecoder[Frequency] =
-    fromTry("Frequency")(Frequency.apply)
+  implicit val frequencyConfigDecoder: ConfigDecoder[String, Frequency] =
+    ConfigDecoder.fromTry[String]("Frequency")(Frequency.apply)
 
-  implicit val timeConfigDecoder: ConfigDecoder[Time] =
-    fromTry("Time")(Time.apply)
+  implicit val timeConfigDecoder: ConfigDecoder[String, Time] =
+    ConfigDecoder.fromTry[String]("Time")(Time.apply)
 }

--- a/tests/shared/src/test/scala/ciris/ConfigDecoderSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigDecoderSpec.scala
@@ -5,7 +5,7 @@ import scala.util.Try
 final class ConfigDecoderSpec extends PropertySpec {
   "ConfigDecoder" when {
     "using mapBoth" should {
-      val decoder = ConfigDecoder.mapBoth(_ => Right("error"), value => Right(value + "123"))
+      val decoder = ConfigDecoder.mapBoth[String](_ => Right("error"), value => Right(value + "123"))
 
       "map the error if there is one" in {
         decoder.decode(nonExistingEntry) shouldBe Right("error")
@@ -19,7 +19,7 @@ final class ConfigDecoderSpec extends PropertySpec {
     }
 
     "using fromTryOption" should {
-      val decoder = ConfigDecoder.fromTryOption("typeName")(value => Try {
+      val decoder = ConfigDecoder.fromTryOption[String]("typeName")(value => Try {
         value match {
           case "some" => Some("ok")
           case "none" => None
@@ -41,7 +41,7 @@ final class ConfigDecoderSpec extends PropertySpec {
     }
 
     "using mapTry" should {
-      val decoder = ConfigDecoder.identity.mapTry("typeName")(value => Try {
+      val decoder = ConfigDecoder.identity[String].mapTry("typeName")(value => Try {
         value match {
           case "ok" => "ok"
           case _ => throw new Error
@@ -58,7 +58,7 @@ final class ConfigDecoderSpec extends PropertySpec {
     }
 
     "using mapCatchNonFatal" should {
-      val decoder = ConfigDecoder.identity.mapCatchNonFatal("typeName") {
+      val decoder = ConfigDecoder.identity[String].mapCatchNonFatal("typeName") {
         case "ok" => "ok"
         case _ => throw new Error
       }
@@ -73,7 +73,7 @@ final class ConfigDecoderSpec extends PropertySpec {
     }
 
     "using collect" should {
-      val decoder = ConfigDecoder.identity.collect("typeName") {
+      val decoder = ConfigDecoder.identity[String].collect("typeName") {
         case value if value == "ok" =>
           "ok"
       }
@@ -88,7 +88,7 @@ final class ConfigDecoderSpec extends PropertySpec {
     }
 
     "using map" should {
-      val decoder = ConfigDecoder.map(value => Right(value + "123"))
+      val decoder = ConfigDecoder.map[String](value => Right(value + "123"))
 
       "keep the error if there is one" in {
         decoder.decode(nonExistingEntry) shouldBe a[Left[_, _]]
@@ -103,7 +103,7 @@ final class ConfigDecoderSpec extends PropertySpec {
 
     "using mapEntryValue" should {
       val f: String => String = _.take(1)
-      val decoder = ConfigDecoder.identity.mapEntryValue(f)
+      val decoder = ConfigDecoder.identity[String].mapEntryValue(f)
 
       "keep the error if there is one" in {
         decoder.decode(nonExistingEntry) shouldBe a[Left[_, _]]

--- a/tests/shared/src/test/scala/ciris/PropertySpec.scala
+++ b/tests/shared/src/test/scala/ciris/PropertySpec.scala
@@ -28,16 +28,16 @@ class PropertySpec extends WordSpec with Matchers with PropertyChecks with Eithe
 
   def fails[A](f: => A): Boolean = Try(f).isFailure
 
-  def readConfigValue[A](value: String)(implicit decoder: ConfigDecoder[A]): ConfigValue[A] =
+  def readConfigValue[A](value: String)(implicit decoder: ConfigDecoder[String, A]): ConfigValue[A] =
     ConfigValue("key")(sourceWith("key" -> value), decoder)
 
-  def readValue[A](value: String)(implicit decoder: ConfigDecoder[A]): Either[ConfigError, A] =
+  def readValue[A](value: String)(implicit decoder: ConfigDecoder[String, A]): Either[ConfigError, A] =
     readConfigValue[A](value).value
 
-  def readNonExistingConfigValue[A](implicit decoder: ConfigDecoder[A]): ConfigValue[A] =
+  def readNonExistingConfigValue[A](implicit decoder: ConfigDecoder[String, A]): ConfigValue[A] =
     ConfigValue("key")(emptySource, decoder)
 
-  def readNonExistingValue[A](implicit decoder: ConfigDecoder[A]): Either[ConfigError, A] =
+  def readNonExistingValue[A](implicit decoder: ConfigDecoder[String, A]): Either[ConfigError, A] =
     decoder.decode(emptySource.read("key"))
 
   def existingEntry(value: String): ConfigEntry[String, String, String] =

--- a/tests/shared/src/test/scala/ciris/spire/decoders/SpireConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/spire/decoders/SpireConfigDecodersSpec.scala
@@ -11,13 +11,13 @@ final class SpireConfigDecodersSpec extends PropertySpec {
     "reading Algebraic" should {
       "successfully read all BigDecimal strings" in {
         forAll { bigDecimal: BigDecimal =>
-          ConfigDecoder[Algebraic].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, Algebraic].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
 
     "reading Interval[Rational]" should {
-      val decoder = ConfigDecoder[Interval[Rational]]
+      val decoder = ConfigDecoder[String, Interval[Rational]]
       def shouldSucceed(value: String) =
         decoder.decode(existingEntry(value)) shouldBe a[Right[_, _]]
 
@@ -51,14 +51,14 @@ final class SpireConfigDecodersSpec extends PropertySpec {
         } yield string.mkString
 
         forAll(gen) { digitString =>
-          ConfigDecoder[Natural].decode(existingEntry(digitString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, Natural].decode(existingEntry(digitString)) shouldBe a[Right[_, _]]
         }
       }
 
       "fail to read non digit-only strings" in {
         forAll { string: String =>
           whenever(string.exists(c => !c.isDigit)) {
-            ConfigDecoder[Natural].decode(existingEntry(string)) shouldBe a[Left[_, _]]
+            ConfigDecoder[String, Natural].decode(existingEntry(string)) shouldBe a[Left[_, _]]
           }
         }
       }
@@ -67,14 +67,14 @@ final class SpireConfigDecodersSpec extends PropertySpec {
     "reading Number" should {
       "successfully read all BigDecimal strings" in {
         forAll { bigDecimal: BigDecimal =>
-          ConfigDecoder[Number].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, Number].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
 
     "reading Polynomial[Rational]" should {
       "successfully read an example polynomial" in {
-        ConfigDecoder[Polynomial[Rational]]
+        ConfigDecoder[String, Polynomial[Rational]]
           .decode(existingEntry("1/5x + 1/3x^2")) shouldBe a[Right[_, _]]
       }
     }
@@ -88,7 +88,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
         } yield s"$n${d.map(d => "/" + d).getOrElse("")}"
 
         forAll(gen) { rationalString =>
-          ConfigDecoder[Rational].decode(existingEntry(rationalString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, Rational].decode(existingEntry(rationalString)) shouldBe a[Right[_, _]]
         }
       }
     }
@@ -96,7 +96,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
     "reading Real" should {
       "successfully read all BigDecimal strings" in {
         forAll { bigDecimal: BigDecimal =>
-          ConfigDecoder[Real].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, Real].decode(existingEntry(bigDecimal.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
@@ -104,20 +104,20 @@ final class SpireConfigDecodersSpec extends PropertySpec {
     "reading SafeLong" should {
       "successfully read all BigInt strings" in {
         forAll { bigInt: BigInt =>
-          ConfigDecoder[SafeLong].decode(existingEntry(bigInt.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, SafeLong].decode(existingEntry(bigInt.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
 
     "reading Trilean" should {
       "successfully read missing value as unknown" in {
-        ConfigDecoder[Trilean].decode(nonExistingEntry) shouldBe Right(Trilean.Unknown)
+        ConfigDecoder[String, Trilean].decode(nonExistingEntry) shouldBe Right(Trilean.Unknown)
       }
 
       "successfully read boolean values" in {
         val gen = Gen.oneOf(mixedCase("true"), mixedCase("false"))
         forAll(gen) { booleanString =>
-          ConfigDecoder[Trilean].decode(existingEntry(booleanString)) shouldBe Right {
+          ConfigDecoder[String, Trilean].decode(existingEntry(booleanString)) shouldBe Right {
             if (booleanString.toBoolean) Trilean.True else Trilean.False
           }
         }
@@ -128,7 +128,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
       "be able to read all representable values" in {
         val gen = Gen.chooseNum(UByte.MinValue.toInt, UByte.MaxValue.toInt)
         forAll(gen) { value =>
-          ConfigDecoder[UByte].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, UByte].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
@@ -137,7 +137,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
       "be able to read all representable values" in {
         val gen = Gen.chooseNum(UInt.MinValue.toLong, UInt.MaxValue.toLong)
         forAll(gen) { value =>
-          ConfigDecoder[UInt].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, UInt].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
@@ -152,7 +152,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
           BigInt(first) + BigInt(second) + zeroOrOne // ULong.MaxValue is 2 * Long.MaxValue + 1
 
         forAll(gen) { value =>
-          ConfigDecoder[ULong].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, ULong].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
         }
       }
     }
@@ -161,7 +161,7 @@ final class SpireConfigDecodersSpec extends PropertySpec {
       "be able to read all representable values" in {
         val gen = Gen.chooseNum(UShort.MinValue.toInt, UShort.MaxValue.toInt)
         forAll(gen) { value =>
-          ConfigDecoder[UShort].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
+          ConfigDecoder[String, UShort].decode(existingEntry(value.toString)) shouldBe a[Right[_, _]]
         }
       }
     }

--- a/tests/shared/src/test/scala/ciris/squants/decoders/SquantsConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/squants/decoders/SquantsConfigDecodersSpec.scala
@@ -102,10 +102,10 @@ final class SquantsConfigDecodersSpec extends PropertySpec with SquantsGenerator
     testDimension(Time, Time.apply)
   }
 
-  def testDimension[A <: Quantity[A]: ConfigDecoder: ClassTag](
+  def testDimension[A <: Quantity[A]: ClassTag](
     dimension: Dimension[A],
     apply: String => Try[A]
-  ): Unit = {
+  )(implicit decoder: ConfigDecoder[String, A]): Unit = {
     val typeName: String = implicitly[ClassTag[A]].runtimeClass.getSimpleName
 
     s"reading a $typeName" should {


### PR DESCRIPTION
Change `ConfigDecoder[B]` to `ConfigDecoder[A, B]` in preparation of supporting configuration sources with values of other types than `String`. Also add partially applied helpers for creating `ConfigDecoder`s, e.g. `ConfigDecoder.catchNonFatal[String]("Int")(_.toInt)`.