### PR TITLE
Change to support arbitrary arity products

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ matrix:
       - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.6/bin/travis_setup.sh | bash -x
     script:
       - sbt ++$TRAVIS_SCALA_VERSION validateNative
+      - if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then
+          sbt ++$TRAVIS_SCALA_VERSION validateDocs
+        fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   - "$HOME/.sbt/boot/"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION validate
+  - if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then sbt ++$TRAVIS_SCALA_VERSION validateDocs; fi
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 matrix:
@@ -25,4 +26,3 @@ matrix:
       - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.6/bin/travis_setup.sh | bash -x
     script:
       - sbt ++$TRAVIS_SCALA_VERSION validateNative
-      - if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then sbt ++$TRAVIS_SCALA_VERSION validateDocs fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,4 @@ matrix:
       - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.6/bin/travis_setup.sh | bash -x
     script:
       - sbt ++$TRAVIS_SCALA_VERSION validateNative
-      - if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then
-          sbt ++$TRAVIS_SCALA_VERSION validateDocs
-        fi
+      - if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then sbt ++$TRAVIS_SCALA_VERSION validateDocs fi

--- a/build.sbt
+++ b/build.sbt
@@ -589,9 +589,6 @@ def addCommandsAlias(name: String, values: List[String]) =
 
 addCommandsAlias("validate", List(
   "clean",
-  "docTests",
-  "docs/unidoc",
-  "docs/tut",
   "testsJS/test",
   "coverage",
   "testsJVM/test",
@@ -600,6 +597,8 @@ addCommandsAlias("validate", List(
 ))
 
 addCommandsAlias("validateNative", nativeModuleNames.map(_ + "/test"))
+
+addCommandsAlias("validateDocs", List("docTests", "docs/unidoc", "docs/tut"))
 
 lazy val scalaTestVersion = "3.0.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -593,6 +593,7 @@ addCommandsAlias("validate", List(
   "coverage",
   "testsJVM/test",
   "coverageReport",
+  "coverageAggregate",
   "mimaReportBinaryIssues"
 ))
 

--- a/docs/src/main/tut/docs/contributing/readme.md
+++ b/docs/src/main/tut/docs/contributing/readme.md
@@ -40,7 +40,8 @@ Below is a list of some useful sbt commands to help you get started.
 * `generateReadme`: generates the readme from the [index page](https://github.com/vlovgr/ciris/blob/master/docs/src/main/tut/index.md).
 * `generateScripts`: generates the script files in the [`scripts`](https://github.com/vlovgr/ciris/tree/master/scripts) directory.
 * `test`: run tests for the application sources.
-* `validate`: compile documentation and run tests.
+* `validate`: compile and run the tests with code coverage enabled.
+* `validateDocs`: run `docTests`, `docs/unidoc`, and `docs/tut` as described above.
 * `validateNative`: run tests for Scala Native modules (requires [Scala Native](http://www.scala-native.org) setup).
 
 ## Submit a pull request

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -60,7 +60,7 @@ source.read("invalidEnv").decodeValue[AppEnvironment]
 Dealing with multiple environments is a common use case for configurations, explained in greater detail in the [Multiple Environments](/docs/environments) section.
 
 ## Generic
-The `ciris-generic` module provides the ability to read unary products, and coproducts using [shapeless][shapeless]. This allows you to load case classes with one argument, including [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless' `Generic` supports. Let's take a brief look at these cases to see how it works in practice. We start by defining a source from which we can read configuration values.
+The `ciris-generic` module provides the ability to decode products and coproducts using [shapeless][shapeless]. This allows you to decode case classes, [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless' `Generic` supports. Let's take a brief look at these cases to see how it works in practice. We start by defining a source from which we can read configuration values.
 
 ```tut:book:reset
 import ciris._
@@ -104,13 +104,30 @@ If we define a product with more than one value:
 final case class TwoValues(value1: Double, value2: Float)
 ```
 
-we will not be able to load it, resulting in an error at compile-time.
+we will try to decode it twice, once as a `Double`, and once as a `Float`.
 
-```tut:fail:book
+```tut:book
 source.read("key").decodeValue[TwoValues]
 ```
 
-Also, if there's no public constructor or apply method:
+You also customize the decoding on a per-type basis. For example, if you have a `ConfigSource` which reads `Map[String, String]` values, you can customize which key gets decoded for which type, like in the following example.
+
+```tut:book
+val mapSource = {
+  val keyType = ConfigKeyType[String]("generic key")
+  ConfigSource.fromMap(keyType)(Map("key" -> Map("key1" -> "1.0", "key2" -> "2.0")))
+}
+
+implicit val decodeDouble: ConfigDecoder[Map[String, String], Double] =
+  ConfigDecoder.catchNonFatal[Map[String, String]]("Double")(map => map("key1").toDouble)
+
+implicit val decodeFloat: ConfigDecoder[Map[String, String], Float] =
+  ConfigDecoder.catchNonFatal[Map[String, String]]("Float")(map => map("key2").toFloat)
+
+mapSource.read("key").decodeValue[TwoValues]
+```
+
+If there is no public constructor or apply method:
 
 ```tut:book
 object PrivateValues {
@@ -124,7 +141,7 @@ object PrivateValues {
 import PrivateValues._
 ```
 
-we will not be able to load it, again resulting in an error at compile-time.
+we will not be able to decode a value, resulting in an error at compile-time.
 
 ```tut:fail:book
 source.read("key").decodeValue[PrivateFloatValue]

--- a/docs/src/main/tut/docs/modules/readme.md
+++ b/docs/src/main/tut/docs/modules/readme.md
@@ -74,7 +74,7 @@ val source = {
 
 We can then define and load a unary product, for example a case class with one value.
 
-```scala
+```tut:book
 final case class DoubleValue(value: Double)
 
 source.read("key").decodeValue[DoubleValue]
@@ -82,7 +82,7 @@ source.read("key").decodeValue[DoubleValue]
 
 It also works for value classes and any other unary products shapeless' `Generic` supports.
 
-```scala
+```tut:book
 final class FloatValue(val value: Float) extends AnyVal
 
 source.read("key").decodeValue[FloatValue]
@@ -90,7 +90,7 @@ source.read("key").decodeValue[FloatValue]
 
 We can also define a shapeless coproduct and load it.
 
-```scala
+```tut:book
 import shapeless.{:+:, CNil}
 
 type DoubleOrFloat = DoubleValue :+: FloatValue :+: CNil


### PR DESCRIPTION
With `ConfigSource` and `ConfigDecoder` being more generic, we can now support products of arbitrary arity with `ciris-generic`.