### PR TITLE
Cats effect module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ lazy val docs = project
           |Ciris is divided into the following set of modules.
           |
           | - The [[ciris.cats cats]] module integrates with [[https://github.com/typelevel/cats cats]] for typeclasses and typeclass instances.
-          | - The [[ciris.cats.effect cats-effect]] module integrates with [[https://github.com/typelevel/cats-effect cats-effect]] for `IO` and typeclasses for effect types.
+          | - The [[ciris.cats.effect cats-effect]] module integrates with [[https://github.com/typelevel/cats-effect cats-effect]] for typeclasses for effect types.
           | - The [[ciris core]] module provides basic functionality and support for reading standard library types.
           | - The [[ciris.enumeratum enumeratum]] module integrates with [[https://github.com/lloydmeta/enumeratum enumeratum]] to be able to read enumerations.
           | - The [[ciris.generic generic]] module uses [[https://github.com/milessabin/shapeless shapeless]] to be able to read products and coproducts.

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val ciris = project
   )
   .aggregate(
     catsJS, catsJVM,
+    catsEffectJS, catsEffectJVM,
     coreJS, coreJVM, coreNative,
     enumeratumJS, enumeratumJVM,
     genericJS, genericJVM, genericNative,
@@ -38,6 +39,21 @@ lazy val cats =
 
 lazy val catsJS = cats.js
 lazy val catsJVM = cats.jvm
+
+lazy val catsEffect =
+  crossProject(JSPlatform, JVMPlatform)
+    .in(file("modules/cats-effect"))
+    .settings(moduleName := "ciris-cats-effect", name := "Ciris cats effect")
+    .settings(libraryDependencies += "org.typelevel" %%% "cats-effect" % "0.8")
+    .settings(scalaSettings)
+    .settings(testSettings)
+    .jsSettings(jsModuleSettings)
+    .jvmSettings(jvmModuleSettings)
+    .settings(releaseSettings)
+    .dependsOn(core)
+
+lazy val catsEffectJS = catsEffect.js
+lazy val catsEffectJVM = catsEffect.jvm
 
 lazy val core =
   crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -140,7 +156,7 @@ lazy val tests =
     .settings(noPublishSettings)
     .settings(testSettings)
     .jsSettings(jsModuleSettings)
-    .dependsOn(cats, core, enumeratum, generic, refined, squants)
+    .dependsOn(cats, catsEffect, core, enumeratum, generic, refined, squants)
 
 lazy val testsJS = tests.js
 lazy val testsJVM = tests.jvm
@@ -183,6 +199,7 @@ lazy val docs = project
       latestVersion in ThisBuild,
       crossScalaVersions,
       BuildInfoKey.map(moduleName in catsJVM) { case (k, v) => "cats" + k.capitalize -> v },
+      BuildInfoKey.map(moduleName in catsEffectJVM) { case (k, v) => "catsEffect" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in coreJVM) { case (k, v) => "core" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in enumeratumJVM) { case (k, v) => "enumeratum" + k.capitalize -> v },
       BuildInfoKey.map(moduleName in genericJVM) { case (k, v) => "generic" + k.capitalize -> v },
@@ -191,6 +208,8 @@ lazy val docs = project
       BuildInfoKey.map(moduleName in squantsJVM) { case (k, v) => "squants" + k.capitalize -> v },
       BuildInfoKey.map(crossScalaVersions in catsJVM) { case (k, v) => "catsJvm" + k.capitalize -> v },
       BuildInfoKey.map(crossScalaVersions in catsJS) { case (k, v) => "catsJs" + k.capitalize -> v },
+      BuildInfoKey.map(crossScalaVersions in catsEffectJVM) { case (k, v) => "catsEffectJvm" + k.capitalize -> v },
+      BuildInfoKey.map(crossScalaVersions in catsEffectJS) { case (k, v) => "catsEffectJs" + k.capitalize -> v },
       BuildInfoKey.map(crossScalaVersions in coreJVM) { case (k, v) => "coreJvm" + k.capitalize -> v },
       BuildInfoKey.map(crossScalaVersions in coreJS) { case (k, v) => "coreJs" + k.capitalize -> v },
       BuildInfoKey.map(crossScalaVersions in coreNative) { case (k, v) => "coreNative" + k.capitalize -> v },
@@ -222,6 +241,7 @@ lazy val docs = project
           |Ciris is divided into the following set of modules.
           |
           | - The [[ciris.cats cats]] module integrates with [[https://github.com/typelevel/cats cats]] for typeclasses and typeclass instances.
+          | - The [[ciris.cats.effect cats-effect]] module integrates with [[https://github.com/typelevel/cats-effect cats-effect]] for `IO` and typeclasses for effect types.
           | - The [[ciris core]] module provides basic functionality and support for reading standard library types.
           | - The [[ciris.enumeratum enumeratum]] module integrates with [[https://github.com/lloydmeta/enumeratum enumeratum]] to be able to read enumerations.
           | - The [[ciris.generic generic]] module uses [[https://github.com/milessabin/shapeless shapeless]] to be able to read products and coproducts.
@@ -247,7 +267,7 @@ lazy val docs = project
       "-doc-root-content", (generateApiIndexFile.value).getAbsolutePath
     )
   )
-  .dependsOn(catsJVM, coreJVM, enumeratumJVM, genericJVM, refinedJVM, spireJVM, squantsJVM)
+  .dependsOn(catsJVM, catsEffectJVM, coreJVM, enumeratumJVM, genericJVM, refinedJVM, spireJVM, squantsJVM)
   .enablePlugins(BuildInfoPlugin, MicrositesPlugin, ScalaUnidocPlugin)
 
 lazy val scala210 = "2.10.7"
@@ -486,6 +506,7 @@ generateScripts in ThisBuild := {
        |~/.coursier/coursier launch -q -P \\
        |  com.lihaoyi:ammonite_2.12.4:1.0.3 \\$coursierArgs
        |  $organizationId:${(moduleName in catsJVM).value}_2.12:$moduleVersion \\
+       |  $organizationId:${(moduleName in catsEffectJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in coreJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in enumeratumJVM).value}_2.12:$moduleVersion \\
        |  $organizationId:${(moduleName in genericJVM).value}_2.12:$moduleVersion \\
@@ -497,6 +518,7 @@ generateScripts in ThisBuild := {
        |        import ciris._,\\
        |        ciris.syntax._,\\
        |        ciris.cats._,\\
+       |        ciris.cats.effect._,\\
        |        ciris.enumeratum._,\\
        |        ciris.generic._,\\
        |        ciris.refined._,\\
@@ -570,7 +592,7 @@ addDateToReleaseNotes in ThisBuild := {
   }
 }
 
-lazy val moduleNames = List[String]("cats", "core", "enumeratum", "generic", "refined", "spire", "squants")
+lazy val moduleNames = List[String]("cats", "catsEffect", "core", "enumeratum", "generic", "refined", "spire", "squants")
 lazy val jsModuleNames = moduleNames.map(_ + "JS")
 lazy val jvmModuleNames = moduleNames.map(_ + "JVM")
 lazy val nativeModuleNames = List("core", "generic").map(_ + "Native")
@@ -583,6 +605,7 @@ addCommandsAlias("publishSignedAll", allModuleNames.map(m => s"+$m/publishSigned
 lazy val crossModules: Seq[(Project, Project, Option[Project])] =
   Seq(
     (catsJVM, catsJS, None),
+    (catsEffectJVM, catsEffectJS, None),
     (coreJVM, coreJS, Some(coreNative)),
     (enumeratumJVM, enumeratumJS, None),
     (genericJVM, genericJS, Some(genericNative)),

--- a/build.sbt
+++ b/build.sbt
@@ -389,6 +389,29 @@ lazy val mimaSettings = Seq(
       case _ =>
         Set.empty
     }
+  },
+  mimaBinaryIssueFilters ++= {
+    import com.typesafe.tools.mima.core._
+    Seq(
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileSync$default$2"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileSync"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileWithNameSync$default$3"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileSync$default$3"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileWithNameSync$default$2"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.CirisPlatformSpecific.fileWithNameSync"),
+      ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris2.catsApplicativeToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris2.catsMonadToCiris"),
+      ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris1.catsFlatMapToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris1.catsApplicativeErrorToCiris"),
+      ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris4.catsFunctorToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris4.catsApplyToCiris"),
+      ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris.catsMonadToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris.catsMonadErrorToCiris"),
+      ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplyToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsFlatMapToCiris"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplicativeToCiris")
+
+    )
   }
 )
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -58,6 +58,7 @@ s"""
  |
  |libraryDependencies ++= Seq(
  |  "$organization" %% "$catsModuleName",
+ |  "$organization" %% "$catsEffectModuleName",
  |  "$organization" %% "$coreModuleName",
  |  "$organization" %% "$enumeratumModuleName",
  |  "$organization" %% "$genericModuleName",
@@ -82,6 +83,7 @@ s"""
  || Module                  | Scala                                                                        | Scala.js                                                                          | Scala Native                                                                       |
  ||-------------------------|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------------------------------------------|
  || `$catsModuleName`       | &#10003; ${catsJvmCrossScalaVersions.map(minorVersion).mkString(", ")}       | &#10003; 0.6 (${catsJsCrossScalaVersions.map(minorVersion).mkString(", ")})       | &#65794;                                                                           |
+ || `$catsEffectModuleName` | &#10003; ${catsEffectJvmCrossScalaVersions.map(minorVersion).mkString(", ")} | &#10003; 0.6 (${catsEffectJsCrossScalaVersions.map(minorVersion).mkString(", ")}) | &#65794;                                                                           |
  || `$coreModuleName`       | &#10003; ${coreJvmCrossScalaVersions.map(minorVersion).mkString(", ")}       | &#10003; 0.6 (${coreJsCrossScalaVersions.map(minorVersion).mkString(", ")})       | &#10003; 0.3 (${coreNativeCrossScalaVersions.map(minorVersion).mkString(", ")})    |
  || `$enumeratumModuleName` | &#10003; ${enumeratumJvmCrossScalaVersions.map(minorVersion).mkString(", ")} | &#10003; 0.6 (${enumeratumJsCrossScalaVersions.map(minorVersion).mkString(", ")}) | &#65794;                                                                           |
  || `$genericModuleName`    | &#10003; ${genericJvmCrossScalaVersions.map(minorVersion).mkString(", ")}    | &#10003; 0.6 (${genericJsCrossScalaVersions.map(minorVersion).mkString(", ")})    | &#10003; 0.3 (${genericNativeCrossScalaVersions.map(minorVersion).mkString(", ")}) |
@@ -100,6 +102,7 @@ The only required module is `ciris-core`, the rest are optional library integrat
 For an explanation of how to use the modules, see the [Modules Overview](https://cir.is/docs/modules) section.
 
 - The `ciris-cats` module provides typeclasses and typeclass instances from [cats][cats].
+- The `ciris-cats-effect` module provides `IO` and typeclasses for effect types from [cats-effect][cats-effect].
 - The `ciris-enumeratum` module allows loading [enumeratum][enumeratum] enumerations.
 - The `ciris-generic` module allows loading more types with [shapeless][shapeless].
 - The `ciris-refined` module allows loading [refined][refined] refinement types.
@@ -112,7 +115,7 @@ If you're using `ciris-generic` with Scala 2.10, you'll need to include the [Mac
 libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
 ```
 
-If you're using `ciris-cats` with Scala 2.11.9 or later, you should enable [partial unification](https://github.com/scala/bug/issues/2712):
+If you're using `ciris-cats` or `ciris-cats-effect` with Scala 2.11.9 or later, you should enable [partial unification](https://github.com/scala/bug/issues/2712):
 
 ```scala
 scalacOptions += "-Ypartial-unification"
@@ -145,6 +148,7 @@ println(
 s"""
  |```scala
  |import $$ivy.`$organization::$catsModuleName:$latestVersion`, ciris.cats._
+ |import $$ivy.`$organization::$catsEffectModuleName:$latestVersion`, ciris.cats.effect._
  |import $$ivy.`$organization::$coreModuleName:$latestVersion`, ciris._, ciris.syntax._
  |import $$ivy.`$organization::$enumeratumModuleName:$latestVersion`, ciris.enumeratum._
  |import $$ivy.`$organization::$genericModuleName:$latestVersion`, ciris.generic._
@@ -178,6 +182,7 @@ If you would like to be involved in building Ciris, check out the [contributing 
 Ciris is available under the MIT license, available at [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT) and in the [license file](https://github.com/vlovgr/ciris/blob/master/license.txt).
 
 [cats]: https://github.com/typelevel/cats
+[cats-effect]: https://github.com/typelevel/cats-effect
 [ciris-aiven-kafka]: https://github.com/ovotech/ciris-aiven-kafka
 [ciris-aws-ssm]: https://github.com/ovotech/ciris-aws-ssm
 [ciris-credstash]: https://github.com/ovotech/ciris-credstash

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -102,7 +102,7 @@ The only required module is `ciris-core`, the rest are optional library integrat
 For an explanation of how to use the modules, see the [Modules Overview](https://cir.is/docs/modules) section.
 
 - The `ciris-cats` module provides typeclasses and typeclass instances from [cats][cats].
-- The `ciris-cats-effect` module provides `IO` and typeclasses for effect types from [cats-effect][cats-effect].
+- The `ciris-cats-effect` module provides typeclasses for effect types from [cats-effect][cats-effect].
 - The `ciris-enumeratum` module allows loading [enumeratum][enumeratum] enumerations.
 - The `ciris-generic` module allows loading more types with [shapeless][shapeless].
 - The `ciris-refined` module allows loading [refined][refined] refinement types.

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,3 +1,3 @@
 latestVersion in ThisBuild := "0.7.0"
 latestBinaryCompatibleVersion in ThisBuild := Some("0.7.0")
-unreleasedModuleNames in ThisBuild := Set()
+unreleasedModuleNames in ThisBuild := Set("ciris-cats-effect")

--- a/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/api/CatsEffectInstancesForCiris.scala
+++ b/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/api/CatsEffectInstancesForCiris.scala
@@ -1,0 +1,15 @@
+package ciris.cats.effect.api
+
+trait CatsEffectInstancesForCiris {
+  implicit def catsEffectSyncToCiris[F[_]](
+    implicit s: _root_.cats.effect.Sync[F]
+  ): _root_.ciris.api.Sync[F] = new _root_.ciris.api.Sync[F] {
+    override def suspend[A](thunk: => F[A]): F[A] = s.suspend(thunk)
+    override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = s.flatMap(fa)(f)
+    override def raiseError[A](e: Throwable): F[A] = s.raiseError(e)
+    override def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] = s.handleErrorWith(fa)(f)
+    override def pure[A](x: A): F[A] = s.pure(x)
+    override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = s.product(fa, fb)
+    override def map[A, B](fa: F[A])(f: A => B): F[B] = s.map(fa)(f)
+  }
+}

--- a/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/package.scala
+++ b/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/package.scala
@@ -1,0 +1,8 @@
+package ciris.cats
+
+import ciris.cats.effect.api.CatsEffectInstancesForCiris
+
+/**
+  * Module providing an integration with [[https://github.com/typelevel/cats-effect cats-effect]].
+  */
+package object effect extends CatsEffectInstancesForCiris

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CatsInstancesForCiris.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CatsInstancesForCiris.scala
@@ -1,13 +1,15 @@
 package ciris.cats.api
 
 trait CatsInstancesForCiris extends CatsInstancesForCiris1 {
-  implicit def catsMonadToCiris[F[_]](
-    implicit m: _root_.cats.Monad[F]
-  ): _root_.ciris.api.Monad[F] = new _root_.ciris.api.Monad[F] {
-    override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = m.flatMap(fa)(f)
-    override def pure[A](x: A): F[A] = m.pure(x)
-    override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = m.product(fa, fb)
-    override def map[A, B](fa: F[A])(f: A => B): F[B] = m.map(fa)(f)
+  implicit def catsMonadErrorToCiris[F[_], E](
+    implicit me: _root_.cats.MonadError[F, E]
+  ): _root_.ciris.api.MonadError[F, E] = new _root_.ciris.api.MonadError[F, E] {
+    override def raiseError[A](e: E): F[A] = me.raiseError(e)
+    override def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A] = me.handleErrorWith(fa)(f)
+    override def pure[A](x: A): F[A] = me.pure(x)
+    override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = me.flatMap(fa)(f)
+    override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = me.product(fa, fb)
+    override def map[A, B](fa: F[A])(f: A => B): F[B] = me.map(fa)(f)
   }
 
   implicit def catsFunctionKToCiris[F[_], G[_]](
@@ -18,6 +20,29 @@ trait CatsInstancesForCiris extends CatsInstancesForCiris1 {
 }
 
 private[ciris] trait CatsInstancesForCiris1 extends CatsInstancesForCiris2 {
+  implicit def catsApplicativeErrorToCiris[F[_], E](
+    implicit ae: _root_.cats.ApplicativeError[F, E]
+  ): _root_.ciris.api.ApplicativeError[F, E] = new _root_.ciris.api.ApplicativeError[F, E] {
+    override def raiseError[A](e: E): F[A] = ae.raiseError(e)
+    override def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A] = ae.handleErrorWith(fa)(f)
+    override def pure[A](x: A): F[A] = ae.pure(x)
+    override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = ae.product(fa, fb)
+    override def map[A, B](fa: F[A])(f: Function[A, B]): F[B] = ae.map(fa)(f)
+  }
+}
+
+private[ciris] trait CatsInstancesForCiris2 extends CatsInstancesForCiris3 {
+  implicit def catsMonadToCiris[F[_]](
+    implicit m: _root_.cats.Monad[F]
+  ): _root_.ciris.api.Monad[F] = new _root_.ciris.api.Monad[F] {
+    override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = m.flatMap(fa)(f)
+    override def pure[A](x: A): F[A] = m.pure(x)
+    override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = m.product(fa, fb)
+    override def map[A, B](fa: F[A])(f: A => B): F[B] = m.map(fa)(f)
+  }
+}
+
+private[ciris] trait CatsInstancesForCiris3 extends CatsInstancesForCiris4 {
   implicit def catsFlatMapToCiris[F[_]](
     implicit fm: _root_.cats.FlatMap[F]
   ): _root_.ciris.api.FlatMap[F] = new _root_.ciris.api.FlatMap[F] {
@@ -25,9 +50,7 @@ private[ciris] trait CatsInstancesForCiris1 extends CatsInstancesForCiris2 {
     override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] = fm.product(fa, fb)
     override def map[A, B](fa: F[A])(f: A => B): F[B] = fm.map(fa)(f)
   }
-}
 
-private[ciris] trait CatsInstancesForCiris2 extends CatsInstancesForCiris3 {
   implicit def catsApplicativeToCiris[F[_]](
     implicit a: _root_.cats.Applicative[F]
   ): _root_.ciris.api.Applicative[F] = new _root_.ciris.api.Applicative[F] {
@@ -37,7 +60,7 @@ private[ciris] trait CatsInstancesForCiris2 extends CatsInstancesForCiris3 {
   }
 }
 
-private[ciris] trait CatsInstancesForCiris3 extends CatsInstancesForCiris4 {
+private[ciris] trait CatsInstancesForCiris4 extends CatsInstancesForCiris5 {
   implicit def catsApplyToCiris[F[_]](
     implicit a: _root_.cats.Apply[F]
   ): _root_.ciris.api.Apply[F] = new _root_.ciris.api.Apply[F] {
@@ -46,7 +69,7 @@ private[ciris] trait CatsInstancesForCiris3 extends CatsInstancesForCiris4 {
   }
 }
 
-private[ciris] trait CatsInstancesForCiris4 {
+private[ciris] trait CatsInstancesForCiris5 {
   implicit def catsFunctorToCiris[F[_]](
     implicit fu: _root_.cats.Functor[F]
   ): _root_.ciris.api.Functor[F] = new _root_.ciris.api.Functor[F] {

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -11,7 +11,11 @@ private[ciris] trait CirisPlatformSpecific {
     * Reads the contents of the specified `file` with `charset`,
     * applies the `modifyFileContents` function on the contents,
     * and attempts to convert the modified file contents to type
-    * `Value`. The result is wrapped in a [[ConfigEntry]].
+    * `Value`. The result is wrapped in a [[ConfigEntry]].<br>
+    * <br>
+    * Note that this function is not pure, and that there is an
+    * alternative pure version of this function available as
+    * [[fileSync]], which suspends the reading of the file.
     *
     * @param file the file of which to read the contents
     * @param modifyFileContents the function to apply on the file contents
@@ -19,6 +23,7 @@ private[ciris] trait CirisPlatformSpecific {
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
     *                defaults to `Charset.defaultCharset`
+    * @param decoder the decoder with which to decode the value
     * @tparam Value the type to convert the value to
     * @return a [[ConfigEntry]] with the result
     * @see [[fileWithName]]
@@ -31,8 +36,47 @@ private[ciris] trait CirisPlatformSpecific {
     file: File,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  )(implicit decoder: ConfigDecoder[String, Value]): ConfigEntry[Id, (File, Charset), String, Value] = {
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[Id, (File, Charset), String, Value] = {
     ConfigSource.File
+      .read((file, charset))
+      .mapValue(modifyFileContents)
+      .decodeValue[Value]
+  }
+
+  /**
+    * Reads the contents of the specified `file` with `charset`,
+    * applies the `modifyFileContents` function on the contents,
+    * and attempts to convert the modified file contents to type
+    * `Value`. The reading of the file is suspended into context
+    * `F` synchronously.<br>
+    * <br>
+    * If suspending into a context is not desired, a non-pure version
+    * of this function is available as [[file]], which attempts to
+    * read the file immediately.
+    *
+    * @param file the file of which to read the contents
+    * @param modifyFileContents the function to apply on the file contents
+    *                           before trying to convert to type `Value`;
+    *                           defaults to not modify the file contents
+    * @param charset the charset of the file to read;
+    *                defaults to `Charset.defaultCharset`
+    * @param decoder the decoder with which to decode the value
+    * @tparam F the context in which to suspend the reading
+    * @tparam Value the type to convert the value to
+    * @return a [[ConfigEntry]] with the result
+    * @see [[fileWithNameSync]]
+    */
+  def fileSync[F[_]: Sync, Value](
+    file: File,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[F, (File, Charset), String, Value] = {
+    ConfigSource.File
+      .suspendF[F]
       .read((file, charset))
       .mapValue(modifyFileContents)
       .decodeValue[Value]
@@ -42,7 +86,12 @@ private[ciris] trait CirisPlatformSpecific {
     * Reads the contents of the specified file `name` with `charset`,
     * applies the `modifyFileContents` function on the contents, and
     * attempts to convert the modified file contents to type `Value`.
-    * The result is wrapped in a [[ConfigEntry]].
+    * The result is wrapped in a [[ConfigEntry]].<br>
+    * <br>
+    * Note that this function is not pure, and that there is an
+    * alternative pure version of this function available as
+    * [[fileWithNameSync]], which suspends the reading of
+    * the file.
     *
     * @param name the name of the file of which to read the contents
     * @param modifyFileContents the function to apply on the file contents
@@ -50,6 +99,7 @@ private[ciris] trait CirisPlatformSpecific {
     *                           defaults to not modify the file contents
     * @param charset the charset of the file to read;
     *                defaults to `Charset.defaultCharset`
+    * @param decoder the decoder with which to decode the value
     * @tparam Value the type to convert the value to
     * @return a [[ConfigEntry]] with the result
     * @see [[file]]
@@ -62,7 +112,41 @@ private[ciris] trait CirisPlatformSpecific {
     name: String,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  )(implicit decoder: ConfigDecoder[String, Value]): ConfigEntry[Id, (File, Charset), String, Value] = {
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[Id, (File, Charset), String, Value] = {
     this.file(new File(name), modifyFileContents, charset)
+  }
+
+  /**
+    * Reads the contents of the specified file `name` with `charset`,
+    * applies the `modifyFileContents` function on the contents, and
+    * attempts to convert the modified file contents to type `Value`.
+    * The reading of the file is suspended into context `F`.<br>
+    * <br>
+    * If suspending into a context is not desired, a non-pure version
+    * of this function is available as [[fileWithName]], which attempts
+    * to read the file immediately.
+    *
+    * @param name the name of the file of which to read the contents
+    * @param modifyFileContents the function to apply on the file contents
+    *                           before trying to convert to type `Value`;
+    *                           defaults to not modify the file contents
+    * @param charset the charset of the file to read;
+    *                defaults to `Charset.defaultCharset`
+    * @param decoder the decoder with which to decode the value
+    * @tparam F the context in which to suspend the reading
+    * @tparam Value the type to convert the value to
+    * @return a [[ConfigEntry]] with the result
+    * @see [[fileSync]]
+    */
+  def fileWithNameSync[F[_]: Sync, Value](
+    name: String,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[F, (File, Charset), String, Value] = {
+    this.fileSync[F, Value](new File(name), modifyFileContents, charset)
   }
 }

--- a/modules/core/native/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/native/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -10,8 +10,23 @@ private[ciris] trait CirisPlatformSpecific {
     file: File,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  )(implicit decoder: ConfigDecoder[String, Value]): ConfigEntry[Id, (File, Charset), String, Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value])
+    : ConfigEntry[Id, (File, Charset), String, Value] = {
     ConfigSource.File
+      .read((file, charset))
+      .mapValue(modifyFileContents)
+      .decodeValue[Value]
+  }
+
+  def fileSync[F[_]: Sync, Value](
+    file: File,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[F, (File, Charset), String, Value] = {
+    ConfigSource.File
+      .suspendF[F]
       .read((file, charset))
       .mapValue(modifyFileContents)
       .decodeValue[Value]
@@ -21,7 +36,18 @@ private[ciris] trait CirisPlatformSpecific {
     name: String,
     modifyFileContents: String => String = identity,
     charset: Charset = Charset.defaultCharset
-  )(implicit decoder: ConfigDecoder[String, Value]): ConfigEntry[Id, (File, Charset), String, Value] = {
+  )(implicit decoder: ConfigDecoder[String, Value])
+    : ConfigEntry[Id, (File, Charset), String, Value] = {
     this.file(new File(name), modifyFileContents, charset)
+  }
+
+  def fileWithNameSync[F[_]: Sync, Value](
+    name: String,
+    modifyFileContents: String => String = identity,
+    charset: Charset = Charset.defaultCharset
+  )(
+    implicit decoder: ConfigDecoder[String, Value]
+  ): ConfigEntry[F, (File, Charset), String, Value] = {
+    this.fileSync[F, Value](new File(name), modifyFileContents, charset)
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -51,7 +51,7 @@ abstract class ConfigSource[F[_], K, V](val keyType: ConfigKeyType[K]) { self =>
     */
   def read(key: K): ConfigEntry[F, K, V, V]
 
-  /***
+  /**
     * Suspends the reading of this configuration source into context `G`.
     *
     * @param f the natural transformation from `F` to `G`

--- a/modules/core/shared/src/main/scala/ciris/api/ApplicativeError.scala
+++ b/modules/core/shared/src/main/scala/ciris/api/ApplicativeError.scala
@@ -1,0 +1,10 @@
+package ciris.api
+
+trait ApplicativeError[F[_], E] extends Applicative[F] {
+  def raiseError[A](e: E): F[A]
+  def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A]
+}
+
+object ApplicativeError {
+  def apply[F[_], E](implicit ae: ApplicativeError[F, E]): ApplicativeError[F, E] = ae
+}

--- a/modules/core/shared/src/main/scala/ciris/api/MonadError.scala
+++ b/modules/core/shared/src/main/scala/ciris/api/MonadError.scala
@@ -1,0 +1,7 @@
+package ciris.api
+
+trait MonadError[F[_], E] extends ApplicativeError[F, E] with Monad[F]
+
+object MonadError {
+  def apply[F[_], E](implicit me: MonadError[F, E]): MonadError[F, E] = me
+}

--- a/modules/core/shared/src/main/scala/ciris/api/Sync.scala
+++ b/modules/core/shared/src/main/scala/ciris/api/Sync.scala
@@ -1,0 +1,9 @@
+package ciris.api
+
+trait Sync[F[_]] extends MonadError[F, Throwable] {
+  def suspend[A](thunk: => F[A]): F[A]
+}
+
+object Sync {
+  def apply[F[_]](implicit sync: Sync[F]): Sync[F] = sync
+}

--- a/tests/jvm/src/test/scala/ciris/CirisPlatformSpecificSpec.scala
+++ b/tests/jvm/src/test/scala/ciris/CirisPlatformSpecificSpec.scala
@@ -19,6 +19,21 @@ final class CirisPlatformSpecificSpec extends JvmPropertySpec {
               }
             }
           }
+
+          "return the expected value, suspending reading" in {
+            import _root_.cats.effect.IO
+            import ciris.cats.effect._
+
+            forAll { value: Int =>
+              withFile(s"$value\n") { (file, charset) =>
+                val fileName = file.toPath.toAbsolutePath.toString
+                val contents = fileWithNameSync[IO, Int](fileName, _.trim).value
+                withFileOverwritten(file)(s"${value + 1}\n") {
+                  contents.unsafeRunSync() shouldBe Right(value + 1)
+                }
+              }
+            }
+          }
         }
 
         "the type cannot be read" should {

--- a/tests/jvm/src/test/scala/ciris/JvmPropertySpec.scala
+++ b/tests/jvm/src/test/scala/ciris/JvmPropertySpec.scala
@@ -13,4 +13,10 @@ class JvmPropertySpec extends PropertySpec {
     try { writer.write(fileContents) } finally { writer.close() }
     try { f(file, Charset.defaultCharset) } finally { file.delete(); () }
   }
+
+  def withFileOverwritten[T](file: JFile)(fileContents: String)(f: => T): T = {
+    val writer = new FileWriter(file)
+    try { writer.write(fileContents) } finally { writer.close() }
+    f
+  }
 }

--- a/tests/jvm/src/test/scala/ciris/cats/api/CatsInstancesForCirisJvmSpec.scala
+++ b/tests/jvm/src/test/scala/ciris/cats/api/CatsInstancesForCirisJvmSpec.scala
@@ -1,0 +1,44 @@
+package ciris.cats.api
+
+import ciris.PropertySpec
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final class CatsInstancesForCirisJvmSpec extends PropertySpec with ScalaFutures {
+  "CatsInstancesForCirisJvm" when {
+    "providing instances for Future" should {
+      "be able to provide all required instances" in {
+        import _root_.cats.implicits._
+        import ciris.api._
+        import ciris.cats._
+
+        implicit val executionContext: ExecutionContext =
+          ExecutionContext.Implicits.global
+
+        Applicative[Future]
+        ApplicativeError[Future, Throwable]
+        val ae = catsApplicativeErrorToCiris[Future, Throwable]
+        ae.raiseError(new Error("message")).failed.futureValue.getCause.getMessage shouldBe "message"
+        ae.handleErrorWith(Future.failed(new Error("message")))(e => Future.successful("ok")).futureValue shouldBe "ok"
+        ae.pure("ok").futureValue shouldBe "ok"
+        ae.product(Future.successful("a"), Future.successful("b")).futureValue shouldBe (("a", "b"))
+        ae.map(Future.successful(" a "))(_.trim).futureValue shouldBe "a"
+
+        Apply[Future]
+        FlatMap[Future]
+        FunctionK[Id, Future]
+        Functor[Future]
+        Monad[Future]
+
+        val me = MonadError[Future, Throwable]
+        me.raiseError(new Error("message")).failed.futureValue.getCause.getMessage shouldBe "message"
+        me.handleErrorWith(Future.failed(new Error("message")))(e => Future.successful("ok")).futureValue shouldBe "ok"
+        me.pure("ok").futureValue shouldBe "ok"
+        me.flatMap(Future.successful("a"))(_ => Future.successful("b")).futureValue shouldBe "b"
+        me.product(Future.successful("a"), Future.successful("b")).futureValue shouldBe (("a", "b"))
+        me.map(Future.successful(" a "))(_.trim).futureValue shouldBe "a"
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/CirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/CirisSpec.scala
@@ -91,14 +91,14 @@ final class CirisSpec extends PropertySpec {
         }
       }
 
-      "be able to lift arguments with argF" in {
-        import _root_.cats.implicits._
-        import ciris.cats._
+      "be able to suspend the reading with argF" in {
+        import _root_.cats.effect.IO
+        import ciris.cats.effect._
 
         forAll(sized(arbitrary[immutable.IndexedSeq[String]])) { args =>
           whenever(args.nonEmpty) {
             forAll(Gen.chooseNum(0, args.length - 1), minSuccessful(10)) { index =>
-              argF[List, String](args)(index).value shouldBe a[List[_]]
+              argF[IO, String](args)(index).value.unsafeRunSync() shouldBe a[Right[_, _]]
             }
           }
         }

--- a/tests/shared/src/test/scala/ciris/CirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/CirisSpec.scala
@@ -2,6 +2,7 @@ package ciris
 
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
+import scala.collection.immutable
 
 final class CirisSpec extends PropertySpec {
   "Ciris" when {
@@ -47,7 +48,7 @@ final class CirisSpec extends PropertySpec {
 
     "loading command-line arguments" should {
       "be able to load all arguments as string" in {
-        forAll(sized(arbitrary[IndexedSeq[String]])) { args =>
+        forAll(sized(arbitrary[immutable.IndexedSeq[String]])) { args =>
           whenever(args.nonEmpty) {
             forAll(Gen.chooseNum(0, args.length - 1), minSuccessful(10)) { index =>
               arg[String](args)(index).value shouldBe a[Right[_, _]]
@@ -57,7 +58,7 @@ final class CirisSpec extends PropertySpec {
       }
 
       "return a failure for non-existing indexes" in {
-        forAll(sized(arbitrary[IndexedSeq[String]])) { args =>
+        forAll(sized(arbitrary[immutable.IndexedSeq[String]])) { args =>
           forAll({
             Gen.oneOf(
               Gen.chooseNum(Int.MinValue, -1),

--- a/tests/shared/src/test/scala/ciris/cats/api/CatsInstancesForCirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/api/CatsInstancesForCirisSpec.scala
@@ -3,8 +3,8 @@ package ciris.cats.api
 import cats.arrow
 import ciris.PropertySpec
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.immutable.Queue
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 final class CatsInstancesForCirisSpec extends PropertySpec {

--- a/tests/shared/src/test/scala/ciris/cats/api/CatsInstancesForCirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/api/CatsInstancesForCirisSpec.scala
@@ -19,11 +19,14 @@ final class CatsInstancesForCirisSpec extends PropertySpec {
           ExecutionContext.Implicits.global
 
         Applicative[Future]
+        ApplicativeError[Future, Throwable]
+        catsApplicativeErrorToCiris[Future, Throwable]
         Apply[Future]
         FlatMap[Future]
         FunctionK[Id, Future]
         Functor[Future]
         Monad[Future]
+        MonadError[Future, Throwable]
       }
     }
 
@@ -104,11 +107,14 @@ final class CatsInstancesForCirisSpec extends PropertySpec {
         import ciris.cats._
 
         Applicative[Try]
+        ApplicativeError[Try, Throwable]
+        catsApplicativeErrorToCiris[Try, Throwable]
         Apply[Try]
         FlatMap[Try]
         FunctionK[Id, Try]
         Functor[Try]
         Monad[Try]
+        MonadError[Try, Throwable]
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
@@ -10,7 +10,14 @@ final class CatsEffectInstancesForCirisSpec extends PropertySpec {
         import _root_.cats.effect.IO
         import ciris.cats.effect._
 
-        Sync[IO]
+        val s = Sync[IO]
+        s.suspend(IO(1)).unsafeRunSync() shouldBe 1
+        s.flatMap(IO(1))(_ => IO(2)).unsafeRunSync() shouldBe 2
+        s.raiseError(new Error("message")).attempt.unsafeRunSync() shouldBe a[Left[_, _]]
+        s.handleErrorWith(IO.raiseError(new Error("message")))(_ => IO(1)).unsafeRunSync() shouldBe 1
+        s.pure(1).unsafeRunSync() shouldBe 1
+        s.product(IO(1), IO(2)).unsafeRunSync() shouldBe ((1, 2))
+        s.map(IO(1))(a => 2 + a).unsafeRunSync() shouldBe 3
       }
     }
   }

--- a/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
@@ -1,0 +1,17 @@
+package ciris.cats.effect.api
+
+import ciris.PropertySpec
+import ciris.api.Sync
+
+final class CatsEffectInstancesForCirisSpec extends PropertySpec {
+  "CatsEffectInstancesForCiris" when {
+    "providing instances for IO" should {
+      "be able to provide all required instances" in {
+        import _root_.cats.effect.IO
+        import ciris.cats.effect._
+
+        Sync[IO]
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add simplified `ApplicativeError`, `MonadError`, and `Sync` from cats and cats-effect.
- Add `ciris-cats-effect` module with conversions from `cats.effect.Sync` to ciris.
- Add `ConfigSource#transformF` for creating a new `ConfigSource` with new context `F[_]`.
- Add `ConfigSource#suspendF` for creating a new `ConfigSource` where reading is suspended into a new context `F[_]: Sync`.
- Add `argF`, `propF`, `fileSync`, and `fileWithNameSync` as pure alternatives, suspending reading into context `F[_]: Sync`.
- Add `envF` for lifting values into `F[_] : Applicative`.
