### PR TITLE
Fix cats and cats-effect ambiguous implicits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -409,8 +409,15 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris.catsMonadErrorToCiris"),
       ProblemFilters.exclude[UpdateForwarderBodyProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplyToCiris"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsFlatMapToCiris"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplicativeToCiris")
-
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplicativeToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris2.catsMonadToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris5.catsFunctorToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris1.catsApplicativeErrorToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris4.catsApplyToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris.catsFunctionKToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris.catsMonadErrorToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsFlatMapToCiris"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("ciris.cats.api.CatsInstancesForCiris3.catsApplicativeToCiris")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -540,6 +540,8 @@ generateScripts in ThisBuild := {
        |        repl.compiler.settings.YpartialUnification.value = true;\\
        |        import ciris._,\\
        |        ciris.syntax._,\\
+       |        ciris.cats._,\\
+       |        ciris.cats.effect._,\\
        |        ciris.enumeratum._,\\
        |        ciris.generic._,\\
        |        ciris.refined._,\\

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val catsEffect =
     .jsSettings(jsModuleSettings)
     .jvmSettings(jvmModuleSettings)
     .settings(releaseSettings)
-    .dependsOn(core)
+    .dependsOn(core, cats)
 
 lazy val catsEffectJS = catsEffect.js
 lazy val catsEffectJVM = catsEffect.jvm

--- a/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/api/CatsEffectInstancesForCiris.scala
+++ b/modules/cats-effect/shared/src/main/scala/ciris/cats/effect/api/CatsEffectInstancesForCiris.scala
@@ -1,6 +1,8 @@
 package ciris.cats.effect.api
 
-trait CatsEffectInstancesForCiris {
+import ciris.cats.api.CatsInstancesForCiris
+
+trait CatsEffectInstancesForCiris extends CatsInstancesForCiris {
   implicit def catsEffectSyncToCiris[F[_]](
     implicit s: _root_.cats.effect.Sync[F]
   ): _root_.ciris.api.Sync[F] = new _root_.ciris.api.Sync[F] {

--- a/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/effect/api/CatsEffectInstancesForCirisSpec.scala
@@ -19,6 +19,21 @@ final class CatsEffectInstancesForCirisSpec extends PropertySpec {
         s.product(IO(1), IO(2)).unsafeRunSync() shouldBe ((1, 2))
         s.map(IO(1))(a => 2 + a).unsafeRunSync() shouldBe 3
       }
+
+      "be able to use it together with ciris-cats" in {
+        import ciris._
+        import ciris.cats._
+        import ciris.cats.effect._
+        import _root_.cats.effect.IO
+
+        case class TestConfig(env: String, prop: String)
+
+        val config =
+          loadConfig(
+            envF[IO, String]("TEST"),
+            propF[IO, String]("file.encoding")
+          )(TestConfig)
+      }
     }
   }
 }


### PR DESCRIPTION
Fix ambiguous implicits between `ciris-cats` and `ciris-cats-effect`.
- Change so that `ciris-cats-effect` depends on `ciris-cats`.
- Change so that `CatsEffectInstancesForCiris` extends `CatsInstancesForCiris `.