### PR TITLE
ConfigDecoder additions and fixes

### DIFF
--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,3 +1,3 @@
 latestVersion in ThisBuild := "0.7.2"
-latestBinaryCompatibleVersion in ThisBuild := Some("0.7.2")
+latestBinaryCompatibleVersion in ThisBuild := None
 unreleasedModuleNames in ThisBuild := Set()

--- a/modules/core/js/src/main/scala/ciris/decoders/ConfigDecoders.scala
+++ b/modules/core/js/src/main/scala/ciris/decoders/ConfigDecoders.scala
@@ -8,3 +8,4 @@ trait ConfigDecoders
     with JavaUtilConfigDecoders
     with MathConfigDecoders
     with PrimitiveConfigDecoders
+    with ScalaUtilConfigDecoders

--- a/modules/core/jvm/src/main/scala/ciris/decoders/ConfigDecoders.scala
+++ b/modules/core/jvm/src/main/scala/ciris/decoders/ConfigDecoders.scala
@@ -12,3 +12,4 @@ trait ConfigDecoders
     with JavaUtilConfigDecoders
     with MathConfigDecoders
     with PrimitiveConfigDecoders
+    with ScalaUtilConfigDecoders

--- a/modules/core/native/src/main/scala/ciris/decoders/ConfigDecoders.scala
+++ b/modules/core/native/src/main/scala/ciris/decoders/ConfigDecoders.scala
@@ -11,3 +11,4 @@ trait ConfigDecoders
     with JavaUtilConfigDecoders
     with MathConfigDecoders
     with PrimitiveConfigDecoders
+    with ScalaUtilConfigDecoders

--- a/modules/core/shared/src/main/scala/ciris/decoders/PrimitiveConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/PrimitiveConfigDecoders.scala
@@ -4,7 +4,13 @@ import ciris.ConfigDecoder
 
 trait PrimitiveConfigDecoders {
   implicit val booleanConfigDecoder: ConfigDecoder[String, Boolean] =
-    ConfigDecoder.catchNonFatal("Boolean")(_.toBoolean)
+    ConfigDecoder.catchNonFatal("Boolean") { s =>
+      s.toLowerCase match {
+        case "yes" | "on" => true
+        case "no" | "off" => false
+        case sLowerCase   => sLowerCase.toBoolean
+      }
+    }
 
   implicit val byteConfigDecoder: ConfigDecoder[String, Byte] =
     ConfigDecoder.catchNonFatal("Byte")(_.toByte)

--- a/modules/core/shared/src/main/scala/ciris/decoders/ScalaUtilConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/ScalaUtilConfigDecoders.scala
@@ -1,0 +1,10 @@
+package ciris.decoders
+
+import ciris.ConfigDecoder
+
+import scala.util.matching.Regex
+
+trait ScalaUtilConfigDecoders {
+  implicit val regexConfigDecoder: ConfigDecoder[String, Regex] =
+    ConfigDecoder.catchNonFatal("Regex")(new Regex(_))
+}

--- a/tests/shared/src/test/scala/ciris/decoders/MathConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/decoders/MathConfigDecodersSpec.scala
@@ -31,6 +31,11 @@ final class MathConfigDecodersSpec extends PropertySpec {
         }
       }
 
+      "successfully read decimal values with precision above default" in {
+        val decimal = "1." + ("0" * (BigDecimal.defaultMathContext.getPrecision - 1)) + "1"
+        readValue[BigDecimal](decimal).right.map(_.toString) shouldBe Right(decimal)
+      }
+
       "return a failure for other values" in {
         forAll { string: String =>
           whenever(fails(BigDecimal(string))) {

--- a/tests/shared/src/test/scala/ciris/decoders/PrimitiveConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/decoders/PrimitiveConfigDecodersSpec.scala
@@ -2,17 +2,21 @@ package ciris.decoders
 
 import ciris.PropertySpec
 
+import org.scalacheck.Gen
+
 final class PrimitiveConfigDecodersSpec extends PropertySpec {
   "PrimitiveConfigDecoders" when {
     "reading a Boolean" should {
       "successfully read true values" in {
-        forAll(mixedCase("true")) { string =>
+        val gen = Gen.oneOf("true", "yes", "on").flatMap(mixedCase)
+        forAll(gen) { string =>
           readValue[Boolean](string) shouldBe Right(true)
         }
       }
 
       "successfully read false values" in {
-        forAll(mixedCase("false")) { string =>
+        val gen = Gen.oneOf("false", "no", "off").flatMap(mixedCase)
+        forAll(gen) { string =>
           readValue[Boolean](string) shouldBe Right(false)
         }
       }

--- a/tests/shared/src/test/scala/ciris/decoders/ScalaUtilConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/decoders/ScalaUtilConfigDecodersSpec.scala
@@ -1,0 +1,26 @@
+package ciris.decoders
+
+import scala.util.matching.Regex
+
+import ciris.PropertySpec
+import org.scalacheck.Gen
+
+final class ScalaUtilConfigDecodersSpec extends PropertySpec {
+  "ScalaUtilConfigDecoders" when {
+    "reading a Regex" should {
+      "successfully read Regex values" in {
+        val examplePatterns = List("[a-z&&[def]]", "(\\D)")
+        forAll(Gen.oneOf(examplePatterns)) { examplePattern =>
+          readValue[Regex](examplePattern) shouldBe a[Right[_, _]]
+        }
+      }
+
+      "return a failure for other values" in {
+        val exampleInvalidPatterns = List("[AB", "(CD[E]")
+        forAll(Gen.oneOf(exampleInvalidPatterns)) { exampleInvalidPattern =>
+          readValue[Regex](exampleInvalidPattern) shouldBe a[Left[_, _]]
+        }
+      }
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.3-SNAPSHOT"
+version in ThisBuild := "0.8.0-SNAPSHOT"


### PR DESCRIPTION
- Add `ConfigDecoder[String, Regex]`.
- Add support for `yes/no` and `on/off` to `ConfigDecoder[String, Boolean]`.
- Workaround loss of precision for `ConfigDecoder[String, BigDecimal]` on Scala 2.10.