### PR TITLE
Change orElse and orNone to work on missing keys

### DIFF
--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -71,7 +71,7 @@ fileEncoding.sourceValue
 fileEncoding.value
 ```
 
-You can also use [`orElse`][orElse] to fall back to other values.
+You can also use [`orElse`][orElse] to fall back to other values if the key is missing from the source.
 
 ```tut:book
 // Uses the value of the file.encoding system property as
@@ -82,7 +82,7 @@ env[String]("FILE_ENCODING").
 
 When using [`orElse`][orElse], we get a [`ConfigValue`][ConfigValue] back, since we've combined the values of multiple [`ConfigEntry`][ConfigEntry]s.
 
-You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but not require any of them to be available.
+You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but not require any of them to be set.
 
 ```tut:book
 env[String]("API_KEY").

--- a/tests/shared/src/test/scala/ciris/ConfigErrorSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigErrorSpec.scala
@@ -19,6 +19,29 @@ final class ConfigErrorSpec extends PropertySpec {
       }
     }
 
+    "using isMissingKey" should {
+      val missingKey =
+        ConfigError.missingKey("key", ConfigKeyType[String]("keyType"))
+
+      "return true for MissingKey" in {
+        missingKey.isMissingKey shouldBe true
+      }
+
+      "return true for a combination of MissingKeys" in {
+        ConfigError.combined(missingKey, missingKey)
+          .isMissingKey shouldBe true
+      }
+
+      "return false for a combination of not only MissingKeys" in {
+        ConfigError.combined(missingKey, ConfigError("other"))
+          .isMissingKey shouldBe false
+      }
+
+      "return false for other errors" in {
+        ConfigError("other").isMissingKey shouldBe false
+      }
+    }
+
     "converting to String" should {
       "have a String representation for custom errors" in {
         ConfigError("abc").toString shouldBe "ConfigError(abc)"


### PR DESCRIPTION
- Add `ConfigError#isMissingKey` for checking whether an error occurred because the key was missing from the `ConfigSource` (for combined errors, whether all errors are due to missing keys).
- Change `ConfigValue#orElse` and `orNone` to only use the alternative value (or `None`) if the error is because of missing keys, as determined by `ConfigError#isMissingKey`.

For example, previously, a type conversion error for `PORT` in the following example:
```
> echo $PORT
changeme

scala> env[Int]("PORT").
     |   orElse(prop[Int]("port").
     |   orNone
res0: ConfigValue[Id, Option[Int]] = ConfigValue(Right(None))
```

would result in using the fallback values. This is probably not what you would expect, and this pull request changes `orElse` and `orNone` to only use fallback values if all previous errors are because of missing keys. In this example, we would stop at the environment variable `PORT`, because it was set but not of the expected type.

```
scala> env[Int]("PORT").
     |   orElse(prop[Int]("port").
     |   orNone
res0: ConfigValue[Id, Option[Int]] = ConfigValue(Left(WrongType(PORT, Environment, Right(changeme), changeme, Int, java.lang.NumberFormatException: For input string: "changeme")))

scala> res0.value.left.map(_.message).toString
res1: String = Left(Environment variable [PORT] with value [changeme] cannot be converted to type [Int]: java.lang.NumberFormatException: For input string: "changeme")
```