### PR TITLE
Change Option decoder to work on missing keys

### DIFF
--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -55,11 +55,13 @@ file[Int](tempFile, _.trim)
 
 Ciris handles errors when reading values, for example if the environment variable or file doesn't exist, or if the value couldn't be converted to the specified type. In the background, these functions are loading values from a [configuration source](/docs/sources) (represented by [`ConfigSource`][ConfigSource]) and converting the value to the specified type with a [configuration decoder](/docs/decoders) (represented by [`ConfigDecoder`][ConfigDecoder]). For a list of currently supported types, refer to the [current supported types](/docs/supported-types) section.
 
-It is also possible to optionally read values with `Option`.
+If you want a value to be optional, and want to use a default value, you can use `Option`.
 
 ```tut:book
-val fileEncoding =
-  env[Option[String]]("FILE_ENCODING")
+// Read environment variable FILE_ENCODING as a String
+// but if it has not been set, return None instead of
+// an error saying it is missing
+val fileEncoding = env[Option[String]]("FILE_ENCODING")
 
 // The unmodified source value is available in the entry,
 // and here we can see that the environment variable has
@@ -69,9 +71,13 @@ fileEncoding.sourceValue
 // We get None back as the value, since the environment
 // variable has not been set
 fileEncoding.value
+
+// If the key has been set, but could not be decoded
+// to the specified type, we keep the error as it is
+prop[Option[Int]]("file.encoding")
 ```
 
-You can also use [`orElse`][orElse] to fall back to other values if the key is missing from the source.
+You can also use [`orElse`][orElse] to fall back to other values if the key is missing.
 
 ```tut:book
 // Uses the value of the file.encoding system property as
@@ -82,7 +88,7 @@ env[String]("FILE_ENCODING").
 
 When using [`orElse`][orElse], we get a [`ConfigValue`][ConfigValue] back, since we've combined the values of multiple [`ConfigEntry`][ConfigEntry]s.
 
-You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but not require any of them to be set.
+You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but not require any keys to be set.
 
 ```tut:book
 env[String]("API_KEY").

--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -55,7 +55,7 @@ file[Int](tempFile, _.trim)
 
 Ciris handles errors when reading values, for example if the environment variable or file doesn't exist, or if the value couldn't be converted to the specified type. In the background, these functions are loading values from a [configuration source](/docs/sources) (represented by [`ConfigSource`][ConfigSource]) and converting the value to the specified type with a [configuration decoder](/docs/decoders) (represented by [`ConfigDecoder`][ConfigDecoder]). For a list of currently supported types, refer to the [current supported types](/docs/supported-types) section.
 
-If you want a value to be optional, and want to use a default value, you can use `Option`.
+If you want a value to be optional, you can use `Option`.
 
 ```tut:book
 // Read environment variable FILE_ENCODING as a String
@@ -77,7 +77,7 @@ fileEncoding.value
 prop[Option[Int]]("file.encoding")
 ```
 
-You can also use [`orElse`][orElse] to fall back to other values if the key is missing.
+Alternatively, you can use [`orElse`][orElse] to fall back to other values if keys are missing.
 
 ```tut:book
 // Uses the value of the file.encoding system property as
@@ -88,7 +88,7 @@ env[String]("FILE_ENCODING").
 
 When using [`orElse`][orElse], we get a [`ConfigValue`][ConfigValue] back, since we've combined the values of multiple [`ConfigEntry`][ConfigEntry]s.
 
-You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but not require any keys to be set.
+You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to other values, but use `None` if all keys are missing.
 
 ```tut:book
 env[String]("API_KEY").

--- a/docs/src/main/tut/docs/supporting-new-sources.md
+++ b/docs/src/main/tut/docs/supporting-new-sources.md
@@ -54,6 +54,8 @@ val propFileSource: ConfigSource[Id, (File, Charset), Map[String, String]] =
 
 The [`ConfigSource`][ConfigSource] is using the existing [`ConfigKeyType.File`][ConfigKeyTypeFile], which uses `(File, Charset)` as the key type. The source also makes use of [`ConfigSource.catchNonFatal`][ConfigSourceCatchNonFatal] to catch any exceptions when reading the properties file. Finally, the properties are converted to a `Map`, and the `FileInputStream` is closed, ignoring any closing exceptions.
 
+If you're creating a custom [`ConfigSource`][ConfigSource] by directly extending [`ConfigSource`][ConfigSource], rather than by using any of the helper functions in the companion object, you need to make sure you provide appropriate [`ConfigError`][ConfigError]s. In particular, you should return [`missingKey`][missingKey] if a key is not available from the source. This error is used by various functions, like [`orElse`][orElse] and [`orNone`][orNone], to fall back to other values if the previous keys have not been set.
+
 The `PropFileKey` case class fully identifies a property file key. It is a combination of the `File`, `Charset`, and `String` key which we are retrieving. The `toString` function has been overridden to provide the `String` representation we would like in error messages. We'll also describe the name and type of the key by creating a [`ConfigKeyType`][ConfigKeyType].
 
 ```tut:silent
@@ -228,6 +230,10 @@ propFileF[UserPortNumber]("port")
 
 [decodeValue]: /api/ciris/ConfigEntry.html#decodeValue[A](implicitdecoder:ciris.ConfigDecoder[V,A],implicitmonad:ciris.api.Monad[F]):ciris.ConfigEntry[F,K,S,A]
 [ConfigDecoder]: /api/ciris/ConfigDecoder.html
+[ConfigError]: /api/ciris/ConfigError.html
+[missingKey]: /api/ciris/ConfigError$.html#missingKey[K](key:K,keyType:ciris.ConfigKeyType[K]):ciris.ConfigError
+[orElse]: /api/ciris/ConfigValue.html#orElse[A>:V](that:=>ciris.ConfigValue[F,A])(implicitm:ciris.api.Monad[F]):ciris.ConfigValue[F,A]
+[orNone]: /api/ciris/ConfigValue.html#orNone:ciris.ConfigValue[F,Option[V]]
 [Monad]: /api/ciris/api/Monad.html
 [env]: /api/ciris/index.html#env[Value](key:String)(implicitdecoder:ciris.ConfigDecoder[String,Value]):ciris.ConfigEntry[ciris.api.Id,String,String,Value]
 [prop]: /api/ciris/index.html#prop[Value](key:String)(implicitdecoder:ciris.ConfigDecoder[String,Value]):ciris.ConfigEntry[ciris.api.Id,String,String,Value]

--- a/modules/core/shared/src/main/scala/ciris/decoders/DerivedConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/DerivedConfigDecoders.scala
@@ -14,8 +14,10 @@ trait DerivedConfigDecoders {
         entry: ConfigEntry[F, K, S, A]
       ): F[Either[ConfigError, Option[B]]] = {
         entry.value.flatMap {
-          case Left(_) => right(Option.empty[B]).pure[F]
-          case Right(_) => decoder.decode(entry).map(_.right.map(Some.apply))
+          case Left(error) if error.isMissingKey =>
+            right(Option.empty[B]).pure[F]
+          case _ =>
+            decoder.decode(entry).map(_.right.map(Some.apply))
         }
       }
     }

--- a/tests/shared/src/test/scala/ciris/decoders/DerivedConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/decoders/DerivedConfigDecodersSpec.scala
@@ -1,18 +1,42 @@
 package ciris.decoders
 
+import ciris.{ConfigError, ConfigEntry, ConfigKeyType}
+import ciris.ConfigError.left
 import ciris.PropertySpec
+import org.scalacheck.Gen
 
 final class DerivedConfigDecodersSpec extends PropertySpec {
   "DerivedConfigDecoders" when {
-    "reading an Option" should {
-      "successfully read existing values" in {
-        forAll { string: String =>
-          readValue[Option[String]](string) shouldBe Right(Some(string))
+    "decoding an Option" when {
+      "the key exists" should {
+        "keep the type conversion error if there is one" in {
+          forAll(Gen.alphaLowerStr) { s =>
+            readValue[Option[Int]](s) shouldBe a[Left[_, _]]
+          }
+        }
+
+        "wrap the value in a Some if type conversion succeeds" in {
+          forAll { n: Int =>
+            readValue[Option[Int]](n.toString) shouldBe Right(Some(n))
+          }
         }
       }
 
-      "return a None for non-existing value" in {
-        readNonExistingValue[Option[String]] shouldBe Right(None)
+      "the key is missing" should {
+        "return a None" in {
+          readNonExistingValue[Option[Int]] shouldBe Right(None)
+        }
+      }
+
+      "the key cannot be retrieved" should {
+        "keep the error" in {
+          val keyType = ConfigKeyType[String]("keyType")
+          val value = left[String](ConfigError("error"))
+
+          ConfigEntry("key", keyType, value)
+            .decodeValue[Option[Int]]
+            .value shouldBe value
+        }
       }
     }
   }


### PR DESCRIPTION
Similarly to #124, this pull request changes the decoder for `Option[A]` to work on missing keys. Previously, the decoder would return `None` for other errors as well. For example, if there was an exception while reading the key, or if the key was set but we were unable to convert it.

```
❯ echo $NUM
changeme

scala> env[Option[Int]]("NUM").value
res0: Id[Either[ConfigError, Option[Int]]] = Right(None)
```

With the changes in this pull request, we now only return `None` when keys are missing.

```
scala> env[Option[Int]]("NUM").value
res0: Id[Either[ConfigError, Option[Int]]] = Left(WrongType(NUM, Environment, Right(changeme), changeme, Int, java.lang.NumberFormatException: For input string: "changeme"))
```
