### PR TITLE
Remove ciris-generic default import from try script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -527,7 +527,6 @@ generateScripts in ThisBuild := {
        |        ciris.cats.effect._,\\
        |        ciris.cats.effect.syntax._,\\
        |        ciris.enumeratum._,\\
-       |        ciris.generic._,\\
        |        ciris.refined._,\\
        |        ciris.refined.syntax._,\\
        |        ciris.spire._,\\

--- a/docs/src/main/tut/docs/generic-module.md
+++ b/docs/src/main/tut/docs/generic-module.md
@@ -5,7 +5,9 @@ permalink: /docs/generic-module
 ---
 
 # Generic Module
-The `ciris-generic` module provides the ability to decode products and coproducts using [shapeless][shapeless]. This allows you to decode case classes, [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless `Generic` supports. Let's take a look at these cases to see how it works. We start by defining a source from which we can read configuration values.
+The `ciris-generic` module provides the ability to decode products and coproducts using [shapeless][shapeless]. This allows you to decode case classes, [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless `Generic` supports. Note that this also includes constructs like `Option`, potentially overriding behaviour already defined in other modules.
+
+Let's take a look at some examples. We start by defining a source from which we can read configuration values.
 
 ```tut:silent
 import ciris.{ConfigKeyType, ConfigSource}

--- a/scripts/try.sh
+++ b/scripts/try.sh
@@ -23,7 +23,6 @@ test -e ~/.coursier/coursier || ( \
         ciris.cats.effect._,\
         ciris.cats.effect.syntax._,\
         ciris.enumeratum._,\
-        ciris.generic._,\
         ciris.refined._,\
         ciris.refined.syntax._,\
         ciris.spire._,\

--- a/scripts/try.typelevel.sh
+++ b/scripts/try.typelevel.sh
@@ -30,7 +30,6 @@ test -e ~/.coursier/coursier || ( \
         ciris.cats.effect._,\
         ciris.cats.effect.syntax._,\
         ciris.enumeratum._,\
-        ciris.generic._,\
         ciris.refined._,\
         ciris.refined.syntax._,\
         ciris.spire._,\


### PR DESCRIPTION
- Remove `ciris-generic` default import from try script to avoid overriding default behaviours.
- Add note to usage guide clarifying `ciris-generic` potentially overriding other behaviours.
