### PR TITLE
Remove the ConfigValue#orElse type parameter

### DIFF
--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -77,13 +77,14 @@ fileEncoding.value
 prop[Option[Int]]("file.encoding")
 ```
 
-Alternatively, you can use [`orElse`][orElse] to fall back to other values if keys are missing.
+Alternatively, you can use [`orElse`][orElse] to fall back to other values if keys are missing.  
+Note that you do not have to specify the type to decode again in the [`orElse`][orElse].
 
 ```tut:book
 // Uses the value of the file.encoding system property as
 // the FILE_ENCODING environment variable has not been set
 env[String]("FILE_ENCODING").
-  orElse(prop[String]("file.encoding"))
+  orElse(prop("file.encoding"))
 ```
 
 When using [`orElse`][orElse], we get a [`ConfigValue`][ConfigValue] back, since we've combined the values of multiple [`ConfigEntry`][ConfigEntry]s.
@@ -92,7 +93,7 @@ You can also combine [`orElse`][orElse] and [`orNone`][orNone] to fall back to o
 
 ```tut:book
 env[String]("API_KEY").
-  orElse(prop[String]("api.key")).
+  orElse(prop("api.key")).
   orNone
 ```
 
@@ -160,7 +161,7 @@ import eu.timepit.refined.auto._
 val config =
   loadConfig(
     env[Secret[ApiKey]]("API_KEY").
-      orElse(prop[Secret[ApiKey]]("api.key")),
+      orElse(prop("api.key")),
     prop[Option[UserPortNumber]]("http.port")
   ) { (apiKey, port) =>
     Config(
@@ -182,7 +183,7 @@ import ciris.{envF, propF}
 val configF =
   loadConfig(
     envF[IO, Secret[ApiKey]]("API_KEY").
-      orElse(propF[IO, Secret[ApiKey]]("api.key")),
+      orElse(propF("api.key")),
     propF[IO, Option[UserPortNumber]]("http.port")
   ) { (apiKey, port) =>
     Config(
@@ -253,7 +254,7 @@ val config =
     case Production =>
       loadConfig(
         env[Secret[ApiKey]]("API_KEY").
-          orElse(prop[Secret[ApiKey]]("api.key")),
+          orElse(prop("api.key")),
         prop[Option[UserPortNumber]]("http.port")
       ) { (apiKey, port) =>
         Config(
@@ -275,7 +276,7 @@ val config =
   loadConfig(
     env[AppEnvironment]("APP_ENV"),
     env[Secret[ApiKey]]("API_KEY").
-      orElse(prop[Secret[ApiKey]]("api.key")),
+      orElse(prop("api.key")),
     prop[Option[UserPortNumber]]("http.port")
   ) { (environment, apiKey, port) =>
     Config(
@@ -302,7 +303,7 @@ val config =
 [ConfigEntry]: /api/ciris/ConfigEntry.html
 [ConfigSource]: /api/ciris/ConfigSource.html
 [ConfigDecoder]: /api/ciris/ConfigDecoder.html
-[orElse]: /api/ciris/ConfigValue.html#orElse[A>:V](that:=>ciris.ConfigValue[F,A])(implicitm:ciris.api.Monad[F]):ciris.ConfigValue[F,A]
+[orElse]: /api/ciris/ConfigValue.html#orElse(that:=>ciris.ConfigValue[F,V])(implicitm:ciris.api.Monad[F]):ciris.ConfigValue[F,V]
 [ConfigValue]: /api/ciris/ConfigValue.html
 [Secret]: /api/ciris/Secret.html
 [cats-effect]: https://github.com/typelevel/cats-effect

--- a/docs/src/main/tut/docs/environments.md
+++ b/docs/src/main/tut/docs/environments.md
@@ -67,7 +67,7 @@ val config =
   loadConfig(
     env[AppEnvironment]("APP_ENV"),
     env[Secret[ApiKey]]("API_KEY").
-      orElse(prop[Secret[ApiKey]]("api.key")),
+      orElse(prop("api.key")),
     prop[Option[UserPortNumber]]("http.port")
   ) { (environment, apiKey, port) =>
     Config(
@@ -106,7 +106,7 @@ val config =
     case Production =>
       loadConfig(
         env[Secret[ApiKey]]("API_KEY").
-          orElse(prop[Secret[ApiKey]]("api.key")),
+          orElse(prop("api.key")),
         prop[Option[UserPortNumber]]("http.port")
       ) { (apiKey, port) =>
         Config(
@@ -152,7 +152,7 @@ val config =
     case Production =>
       loadConfig(
         env[Secret[ApiKey]]("API_KEY").
-          orElse(prop[Secret[ApiKey]]("api.key")),
+          orElse(prop("api.key")),
         prop[Option[UserPortNumber]]("http.port")
       )(configWithDefaults)
   }

--- a/docs/src/main/tut/docs/supporting-new-sources.md
+++ b/docs/src/main/tut/docs/supporting-new-sources.md
@@ -232,7 +232,7 @@ propFileF[UserPortNumber]("port")
 [ConfigDecoder]: /api/ciris/ConfigDecoder.html
 [ConfigError]: /api/ciris/ConfigError.html
 [missingKey]: /api/ciris/ConfigError$.html#missingKey[K](key:K,keyType:ciris.ConfigKeyType[K]):ciris.ConfigError
-[orElse]: /api/ciris/ConfigValue.html#orElse[A>:V](that:=>ciris.ConfigValue[F,A])(implicitm:ciris.api.Monad[F]):ciris.ConfigValue[F,A]
+[orElse]: /api/ciris/ConfigValue.html#orElse(that:=>ciris.ConfigValue[F,V])(implicitm:ciris.api.Monad[F]):ciris.ConfigValue[F,V]
 [orNone]: /api/ciris/ConfigValue.html#orNone:ciris.ConfigValue[F,Option[V]]
 [Monad]: /api/ciris/api/Monad.html
 [env]: /api/ciris/index.html#env[Value](key:String)(implicitdecoder:ciris.ConfigDecoder[String,Value]):ciris.ConfigEntry[ciris.api.Id,String,String,Value]

--- a/docs/src/main/tut/docs/validation.md
+++ b/docs/src/main/tut/docs/validation.md
@@ -33,7 +33,7 @@ import ciris.{env, prop}
 import ciris.refined._
 
 env[ApiKey]("API_KEY").
-  orElse(prop[ApiKey]("api.key")).
+  orElse(prop("api.key")).
   orNone
 ```
 
@@ -63,7 +63,7 @@ Also, if we want to avoid accidentally logging secrets, we can use [`Secret`][Se
 import ciris.Secret
 
 env[Secret[ApiKey]]("API_KEY").
-  orElse(prop[Secret[ApiKey]]("api.key")).
+  orElse(prop("api.key")).
   orNone
 ```
 
@@ -75,7 +75,7 @@ Refinement types are not limited to `String`s, and [refined](/docs/refined-modul
 import eu.timepit.refined.types.net.UserPortNumber
 
 env[UserPortNumber]("PORT").
-  orElse(prop[UserPortNumber]("http.port")).
+  orElse(prop("http.port")).
   orNone
 ```
 
@@ -105,7 +105,7 @@ import ciris.loadConfig
 val config =
   loadConfig(
     env[Secret[ApiKey]]("API_KEY").
-      orElse(prop[Secret[ApiKey]]("api.key")),
+      orElse(prop("api.key")),
     prop[Option[UserPortNumber]]("http.port")
   ) { (apiKey, port) =>
     Config(

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -24,14 +24,14 @@ abstract class ConfigValue[F[_]: Apply, V] {
     * {{{
     * scala> val apiKey =
     *      |  env[String]("API_KEY").
-    *      |    orElse(prop[String]("api.key"))
-    * apiKey: ConfigValue[api.Id, String] =  ConfigValue(Left(Combined(MissingKey(API_KEY, Environment), MissingKey(api.key, Property))))
+    *      |    orElse(prop("api.key"))
+    * apiKey: ConfigValue[api.Id, String] = ConfigValue(Left(Combined(MissingKey(API_KEY, Environment), MissingKey(api.key, Property))))
     *
     * scala> apiKey.value.left.map(_.message).toString
     * res0: String = Left(Missing environment variable [API_KEY] and missing system property [api.key])
     *
     * scala> env[String]("FILE_ENCODING").
-    *      |   orElse(prop[String]("file.encoding"))
+    *      |   orElse(prop("file.encoding"))
     * res1: ConfigValue[api.Id, String] = ConfigValue(Right(UTF8))
     * }}}
     *
@@ -41,7 +41,7 @@ abstract class ConfigValue[F[_]: Apply, V] {
     *
     * {{{
     * scala> prop[Int]("file.encoding").
-    *      |   orElse(env[Int]("FILE_ENCODING"))
+    *      |   orElse(env("FILE_ENCODING"))
     * res2: ConfigValue[api.Id, Int] = ConfigValue(Left(WrongType(file.encoding, Property, Right(UTF8), UTF8, Int, java.lang.NumberFormatException: For input string: "UTF8")))
     * }}}
     *
@@ -51,11 +51,10 @@ abstract class ConfigValue[F[_]: Apply, V] {
     *
     * @param that the [[ConfigValue]] to use if this value is unavailable
     *             due to the key missing from the [[ConfigSource]]
-    * @tparam A the value type of that [[ConfigValue]]
     * @return a new [[ConfigValue]]
     */
-  final def orElse[A >: V](that: => ConfigValue[F, A])(implicit m: Monad[F]): ConfigValue[F, A] =
-    ConfigValue.applyF[F, A] {
+  final def orElse(that: => ConfigValue[F, V])(implicit m: Monad[F]): ConfigValue[F, V] =
+    ConfigValue.applyF[F, V] {
       this.value.flatMap {
         case Left(thisError) if thisError.isMissingKey =>
           that.value.map {
@@ -63,8 +62,7 @@ abstract class ConfigValue[F[_]: Apply, V] {
             case Left(thatError)  => Left(thisError combine thatError)
           }
 
-        case other =>
-          (other: Either[ConfigError, A]).pure[F]
+        case other => other.pure[F]
       }
     }
 
@@ -76,7 +74,7 @@ abstract class ConfigValue[F[_]: Apply, V] {
     *
     * {{{
     * scala> env[String]("API_KEY").
-    *      |   orElse(prop[String]("api.key")).
+    *      |   orElse(prop("api.key")).
     *      |   orNone
     * res0: ConfigValue[api.Id,Option[String]] = ConfigValue(Right(None))
     * }}}

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -39,20 +39,20 @@ final class ConfigValueSpec extends PropertySpec {
 
       "use the alternative value if the first key is missing" in {
         readNonExistingConfigEntry[String]
-          .orElse(readConfigEntry[String]("value"))
+          .orElse(readConfigEntry("value"))
           .value shouldBe Right("value")
       }
 
       "use the alternative value if the first keys are missing" in {
         readNonExistingConfigEntry[String]
-          .orElse(readNonExistingConfigEntry[String])
-          .orElse(readConfigEntry[String]("value"))
+          .orElse(readNonExistingConfigEntry)
+          .orElse(readConfigEntry("value"))
           .value shouldBe Right("value")
       }
 
       "accumulate errors if both values are unavailable" in {
         readNonExistingConfigEntry[String]
-          .orElse(readNonExistingConfigEntry[String])
+          .orElse(readNonExistingConfigEntry)
           .value
           .left
           .map(_.message) shouldBe Left("Missing test key [key] and missing test key [key]")
@@ -68,7 +68,7 @@ final class ConfigValueSpec extends PropertySpec {
 
       "use None for combined missing keys" in {
         readNonExistingConfigEntry[String]
-          .orElse(readNonExistingConfigEntry[String])
+          .orElse(readNonExistingConfigEntry)
           .orNone
           .value shouldBe Right(None)
       }
@@ -82,7 +82,7 @@ final class ConfigValueSpec extends PropertySpec {
 
       "keep a combined error that is not only missing keys" in {
         readNonExistingConfigEntry[String]
-          .orElse(ConfigValue(ConfigError.left[String](ConfigError("error"))))
+          .orElse(ConfigValue(ConfigError.left(ConfigError("error"))))
           .orNone
           .value
           .left


### PR DESCRIPTION
This pull request removes the `A >: V` type parameter on `ConfigValue#orElse`. The benefit of removing it is that we no longer have to repeat ourselves by specifying the type to decode in the `orElse` argument, since the type can now be properly inferred.

```
scala> env[String]("API_KEY").
     |   orElse(prop("api.key")).
     |   orNone
res0: ConfigValue[Id, Option[String]] = ConfigValue(Right(None))
```

This includes also being able to infer the context type.

```
scala> envF[IO, String]("API_KEY").
     |   orElse(propF("api.key")).
     |   orNone
res0: ConfigValue[IO, Option[String]] = ConfigValue(<function1>)
```