### PR TITLE
Add support for hiding and redacting sensitive details

### DIFF
--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -74,7 +74,7 @@ fileEncoding.value
 
 // If the key has been set, but could not be decoded
 // to the specified type, we keep the error as it is
-prop[Option[Int]]("file.encoding")
+prop[Option[Int]]("file.encoding").value
 ```
 
 Alternatively, you can use [`orElse`][orElse] to fall back to other values if keys are missing.  

--- a/docs/src/main/tut/docs/logging.md
+++ b/docs/src/main/tut/docs/logging.md
@@ -49,6 +49,25 @@ The perhaps easiest way to log the configuration is to use `println`. As you can
 println(config)
 ```
 
+When loading configuration values with type [`Secret`][Secret], Ciris will make sure that no sensitive details are included in error messages. In general, potentially sensitive information is only included in results from functions with `value` in the name: for example, [`value`][ConfigEntry#value], [`sourceValue`][ConfigEntry#sourceValue], [`toStringWithValue`][ConfigEntry#toStringWithValue], and [`toStringWithValues`][ConfigEntry#toStringWithValues]. So make sure you are not accidentally logging the results from such functions.
+
+```tut:book
+import ciris.{env, prop}
+
+env[Secret[Int]]("FILE_ENCODING").
+  orElse(prop("file.encoding")).
+  value.left.map(_.message)
+
+val fileEncoding =
+  prop[Secret[String]]("file.encoding")
+
+fileEncoding.sourceValue
+
+fileEncoding.value
+
+fileEncoding.toStringWithValue
+```
+
 ## Logging Improvements
 Relying on `toString` works reasonably well for small configurations, like in the example shown above, but as your configuration grows in size, it can be considerably more difficult to determine which value is which in the output. Making use of `toString` also means we're relying on every type having implemented an appropriate `toString` function, which might not always be the case.
 
@@ -75,3 +94,7 @@ println(config.show)
 [kittens]: https://github.com/milessabin/kittens
 [Show]: https://typelevel.org/cats/typeclasses/show.html
 [shapeless]: https://github.com/milessabin/shapeless
+[ConfigEntry#value]: /api/ciris/ConfigEntry.html#value:F[Either[ciris.ConfigError,V]]
+[ConfigEntry#sourceValue]: /api/ciris/ConfigEntry.html#sourceValue:F[Either[ciris.ConfigError,S]]
+[ConfigEntry#toStringWithValue]: /api/ciris/ConfigEntry.html#toStringWithValue:String
+[ConfigEntry#toStringWithValues]: /api/ciris/ConfigEntry.html#toStringWithValues:String

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
@@ -5,24 +5,16 @@ import ciris._
 
 trait CirisInstancesForCats {
   implicit def showConfigEntry[F[_], K, S, V](
-    implicit showK: Show[K],
-    showS: Show[F[Either[ConfigError, S]]],
-    showV: Show[F[Either[ConfigError, V]]]
+    implicit showKey: Show[K],
+    showKeyType: Show[ConfigKeyType[K]]
   ): Show[ConfigEntry[F, K, S, V]] = Show.show { entry =>
-    val key = showK.show(entry.key)
-    val keyType = showConfigKeyType[K].show(entry.keyType)
-    val sourceValue = showS.show(entry.sourceValue)
-    val value = showV.show(entry.value)
-
-    if (sourceValue == value) s"ConfigEntry($key, $keyType, $value)"
-    else s"ConfigEntry($key, $keyType, $sourceValue, $value)"
+    val key = showKey.show(entry.key)
+    val keyType = showKeyType.show(entry.keyType)
+    s"ConfigEntry($key, $keyType)"
   }
 
-  implicit def showConfigValue[F[_], V](
-    implicit show: Show[F[Either[ConfigError, V]]]
-  ): Show[ConfigValue[F, V]] = Show.show { value =>
-    s"ConfigValue(${show.show(value.value)})"
-  }
+  implicit def showConfigValue[F[_], V]: Show[ConfigValue[F, V]] =
+    Show.fromToString
 
   implicit val showConfigError: Show[ConfigError] =
     Show.fromToString

--- a/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
+++ b/modules/core/jvm/src/main/scala/ciris/CirisPlatformSpecific.scala
@@ -28,8 +28,8 @@ private[ciris] trait CirisPlatformSpecific {
     * @return a [[ConfigEntry]] with the result
     * @see [[fileWithName]]
     * @example {{{
-    * scala> file[Double](new java.io.File("/number.txt"))
-    * res0: ConfigEntry[api.Id, (java.io.File,java.nio.charset.Charset), String, Double] = ConfigEntry((/number.txt,UTF-8), ConfigKeyType(file), Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
+    * scala> file[Double](new java.io.File("/number.txt")).toStringWithValues
+    * res0: String = ConfigEntry((/number.txt,UTF-8), ConfigKeyType(file), Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
     * }}}
     */
   def file[Value](
@@ -104,8 +104,8 @@ private[ciris] trait CirisPlatformSpecific {
     * @return a [[ConfigEntry]] with the result
     * @see [[file]]
     * @example {{{
-    * scala> fileWithName[Double]("/number.txt")
-    * res0: ConfigEntry[api.Id, (java.io.File,java.nio.charset.Charset), String, Double] = ConfigEntry((/number.txt,UTF-8), ConfigKeyType(file), Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
+    * scala> fileWithName[Double]("/number.txt").toStringWithValues
+    * res0: String = ConfigEntry((/number.txt,UTF-8), ConfigKeyType(file), Left(ReadException((/number.txt,UTF-8), ConfigKeyType(file), java.io.FileNotFoundException: /number.txt (No such file or directory))))
     * }}}
     */
   def fileWithName[Value](

--- a/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
@@ -16,7 +16,7 @@ import ciris.api.syntax._
   * To create a [[ConfigEntry]], use [[ConfigEntry#apply]].
   * {{{
   * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-  * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+  * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
   * }}}
   *
   * @param key the key which was retrieved from the configuration source
@@ -64,10 +64,11 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     *         or a [[ConfigError]] if the value is not available
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value "))
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value ))
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
-    * scala> entry.mapValue(_.trim)
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
+    * scala> entry.mapValue(_.trim).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value ), Right(value))
+    *
     * }}}
     */
   def mapValue[A](f: V => A): ConfigEntry[F, K, S, A] =
@@ -85,10 +86,10 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     *         or a [[ConfigError]] if the value is not available
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
-    * scala> entry.flatMapValue(v => if(v.length > 2) Right(v) else Left(ConfigError("error")))
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * scala> entry.flatMapValue(v => if(v.length > 2) Right(v) else Left(ConfigError("error"))).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value))
     * }}}
     */
   def flatMapValue[A](f: V => Either[ConfigError, A]): ConfigEntry[F, K, S, A] =
@@ -104,10 +105,10 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
-    * scala> entry.withValue(Right(123))
-    * res0: ConfigEntry[api.Id, String, String, Int] = ConfigEntry(key, Environment, Right(value), Right(123))
+    * scala> entry.withValue(Right(123)).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value), Right(123))
     * }}}
     */
   def withValue[A](value: Either[ConfigError, A]): ConfigEntry[F, K, S, A] =
@@ -124,13 +125,13 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
-    * scala> entry.withValueF(Right(123))
-    * res0: ConfigEntry[api.Id, String, String, Int] = ConfigEntry(key, Environment, Right(value), Right(123))
+    * scala> entry.withValueF(Right(123)).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value), Right(123))
     *
-    * scala> entry.withValue(Right(456))
-    * res0: ConfigEntry[api.Id, String, String, Int] = ConfigEntry(key, Environment, Right(value), Right(456))
+    * scala> entry.withValue(Right(456)).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value), Right(456))
     * }}}
     */
   def withValueF[A](value: F[Either[ConfigError, A]]): ConfigEntry[F, K, S, A] =
@@ -147,13 +148,13 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value "))
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value ))
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
-    * scala> entry.transformValue(_.right.map(_.trim))
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
+    * scala> entry.transformValue(_.right.map(_.trim)).toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Right(value ), Right(value))
     *
-    * scala> entry.mapValue(_.trim)
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value ), Right(value))
+    * scala> entry.mapValue(_.trim).toStringWithValues
+    * res1: String = ConfigEntry(key, Environment, Right(value ), Right(value))
     * }}}
     */
   def transformValue[A](
@@ -177,22 +178,22 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     s"ConfigEntry($key, $keyType)"
 
   /**
-    * Returns a [[String]] representation of this [[ConfigEntry]]
+    * Returns a `String` representation of this [[ConfigEntry]]
     * including the value. If the value is potentially sensitive,
     * then be careful to not include it in log output.
     *
-    * @return a [[String]] representation with the value
+    * @return a `String` representation with the value
     */
   override def toStringWithValue: String =
     s"ConfigEntry($key, $keyType, $value)"
 
   /**
-    * Returns a [[String]] representation of this [[ConfigEntry]]
+    * Returns a `String` representation of this [[ConfigEntry]]
     * including both the source value and value. If the values
     * include potentially sensitive details, be careful to
     * not include them in log output.
     *
-    * @return a [[String]] representation with values
+    * @return a `String` representation with values
     */
   def toStringWithValues: String = {
     val sourceValueString = sourceValue.toString
@@ -223,10 +224,10 @@ object ConfigEntry {
     * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
     * scala> ConfigEntry.applyF[api.Id, String, String]("key", ConfigKeyType.Environment, Right("value"))
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     * }}}
     */
   def apply[K, S](
@@ -258,10 +259,10 @@ object ConfigEntry {
     * @return a new [[ConfigEntry]]
     * @example {{{
     * scala> ConfigEntry.applyF[api.Id, String, String]("key", ConfigKeyType.Environment, Right("value"))
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     *
     * scala> ConfigEntry("key", ConfigKeyType.Environment, Right("value"))
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Right(value))
+    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment)
     * }}}
     */
   def applyF[F[_]: Apply, K, S](

--- a/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
@@ -173,7 +173,18 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
   def transformF[G[_]: Apply](implicit f: F ~> G): ConfigEntry[G, K, S, V] =
     new ConfigEntry(key, keyType, f(sourceValue), f(value))
 
-  override def toString: String = {
+  override def toString: String =
+    s"ConfigEntry($key, $keyType)"
+
+  /**
+    * Returns a [[String]] representation of this [[ConfigEntry]]
+    * including both the source value and value. If the values
+    * include potentially sensitive details, be careful to
+    * not include them in log output.
+    *
+    * @return a [[String]] representation with values
+    */
+  def toStringWithValues: String = {
     val sourceValueString = sourceValue.toString
     val valueString = value.toString
 

--- a/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigEntry.scala
@@ -178,6 +178,16 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
 
   /**
     * Returns a [[String]] representation of this [[ConfigEntry]]
+    * including the value. If the value is potentially sensitive,
+    * then be careful to not include it in log output.
+    *
+    * @return a [[String]] representation with the value
+    */
+  override def toStringWithValue: String =
+    s"ConfigEntry($key, $keyType, $value)"
+
+  /**
+    * Returns a [[String]] representation of this [[ConfigEntry]]
     * including both the source value and value. If the values
     * include potentially sensitive details, be careful to
     * not include them in log output.

--- a/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSource.scala
@@ -30,8 +30,8 @@ import scala.util.{Failure, Success, Try}
   * scala> val source = ConfigSource(ConfigKeyType[String]("identity key"))(key => Right(key))
   * source: ConfigSource[api.Id, String, String] = ConfigSource(ConfigKeyType(identity key))
   *
-  * scala> source.read("key")
-  * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
+  * scala> source.read("key").toStringWithValues
+  * res0: String = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
   * }}}
   */
 abstract class ConfigSource[F[_], K, V](val keyType: ConfigKeyType[K]) { self =>
@@ -45,8 +45,8 @@ abstract class ConfigSource[F[_], K, V](val keyType: ConfigKeyType[K]) { self =>
     * @param key the key for which to read the value
     * @return a [[ConfigEntry]] with the result
     * @example {{{
-    * scala> val entry = ConfigSource.Environment.read("key")
-    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> ConfigSource.Environment.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def read(key: K): ConfigEntry[F, K, V, V]
@@ -92,8 +92,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource(ConfigKeyType[String]("identity key"))(key => Right(key))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(ConfigKeyType(identity key))
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
     * }}}
     */
   def apply[K, V](keyType: ConfigKeyType[K])(
@@ -119,8 +119,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.applyF[api.Id, String, String](ConfigKeyType[String]("identity key"))(key => Right(key))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(ConfigKeyType(identity key))
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, ConfigKeyType(identity key), Right(key))
     * }}}
     */
   def applyF[F[_]: Apply, K, V](keyType: ConfigKeyType[K])(
@@ -147,8 +147,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromOption(ConfigKeyType.Environment)(sys.env.get)
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromOption[K, V](keyType: ConfigKeyType[K])(
@@ -174,8 +174,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromOptionF[api.Id, String, String](ConfigKeyType.Environment)(sys.env.get)
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromOptionF[F[_]: Apply, K, V](keyType: ConfigKeyType[K])(
@@ -271,11 +271,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.failed[String, String](ConfigKeyType.Environment)(ConfigError("error"))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key1")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key1, Environment, Left(ConfigError(error)))
+    * scala> source.read("key1").toStringWithValues
+    * res0: String = ConfigEntry(key1, Environment, Left(ConfigError(error)))
     *
-    * scala> source.read("key2")
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key2, Environment, Left(ConfigError(error)))
+    * scala> source.read("key2").toStringWithValues
+    * res1: String = ConfigEntry(key2, Environment, Left(ConfigError(error)))
     * }}}
     */
   def failed[K, V](keyType: ConfigKeyType[K])(
@@ -302,11 +302,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.failedF[api.Id, String, String](ConfigKeyType.Environment)(ConfigError("error"))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key1")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key1, Environment, Left(ConfigError(error)))
+    * scala> source.read("key1").toStringWithValues
+    * res0: String = ConfigEntry(key1, Environment, Left(ConfigError(error)))
     *
-    * scala> source.read("key2")
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key2, Environment, Left(ConfigError(error)))
+    * scala> source.read("key2").toStringWithValues
+    * res1: String = ConfigEntry(key2, Environment, Left(ConfigError(error)))
     * }}}
     */
   def failedF[F[_]: Apply, K, V](keyType: ConfigKeyType[K])(
@@ -329,8 +329,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromMap(ConfigKeyType.Environment)(sys.env)
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromMap[K, V](keyType: ConfigKeyType[K])(
@@ -357,8 +357,8 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromMapF[api.Id, String, String](ConfigKeyType.Environment)(sys.env)
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Environment)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def fromMapF[F[_]: Apply, K, V](keyType: ConfigKeyType[K])(
@@ -383,14 +383,14 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromEntries(ConfigKeyType.Argument)(0 -> "abc", 0 -> "def", 1 -> "ghi")
     * source: ConfigSource[api.Id, Int, String] = ConfigSource(Argument)
     *
-    * scala> source.read(0)
-    * res0: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(0, Argument, Right(def))
+    * scala> source.read(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(def))
     *
-    * scala> source.read(1)
-    * res1: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(1, Argument, Right(ghi))
+    * scala> source.read(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Right(ghi))
     *
-    * scala> source.read(2)
-    * res2: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(2, Argument, Left(MissingKey(2, Argument)))
+    * scala> source.read(2).toStringWithValues
+    * res2: String = ConfigEntry(2, Argument, Left(MissingKey(2, Argument)))
     * }}}
     */
   def fromEntries[K, V](keyType: ConfigKeyType[K])(
@@ -438,11 +438,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromTry(ConfigKeyType.Argument)(index => scala.util.Try(Vector("a")(index)))
     * source: ConfigSource[api.Id, Int, String] = ConfigSource(Argument)
     *
-    * scala> source.read(0)
-    * res0: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(0, Argument, Right(a))
+    * scala> source.read(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(a))
     *
-    * scala> source.read(1)
-    * res1: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * scala> source.read(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def fromTry[K, V](keyType: ConfigKeyType[K])(
@@ -491,11 +491,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromTryOption(ConfigKeyType.Property)(key => scala.util.Try(sys.props.get(key)))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Property)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
     *
-    * scala> source.read("")
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
+    * scala> source.read("").toStringWithValues
+    * res1: String = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
     * }}}
     */
   def fromTryOption[K, V](keyType: ConfigKeyType[K])(
@@ -520,11 +520,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.fromTryOptionF[api.Id, String, String](ConfigKeyType.Property)(key => scala.util.Try(sys.props.get(key)))
     * source: ConfigSource[api.Id, String, String] = ConfigSource(Property)
     *
-    * scala> source.read("key")
-    * res0: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
+    * scala> source.read("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
     *
-    * scala> source.read("")
-    * res1: ConfigEntry[api.Id, String, String, String] = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
+    * scala> source.read("").toStringWithValues
+    * res1: String = ConfigEntry(, Property, Left(ReadException(, Property, java.lang.IllegalArgumentException: key can't be empty)))
     * }}}
     */
   def fromTryOptionF[F[_]: Apply, K, V](keyType: ConfigKeyType[K])(
@@ -555,11 +555,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.catchNonFatal(ConfigKeyType.Argument)(Vector("a"))
     * source: ConfigSource[api.Id, Int, String] = ConfigSource(Argument)
     *
-    * scala> source.read(0)
-    * res0: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(0, Argument, Right(a))
+    * scala> source.read(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(a))
     *
-    * scala> source.read(1)
-    * res1: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
+    * scala> source.read(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Left(ReadException(1, Argument, java.lang.IndexOutOfBoundsException: 1)))
     * }}}
     */
   def catchNonFatal[K, V](keyType: ConfigKeyType[K])(
@@ -610,11 +610,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.byIndex(ConfigKeyType.Argument)(Vector("a"))
     * source: ConfigSource[api.Id, Int, String] = ConfigSource(Argument)
     *
-    * scala> source.read(0)
-    * res0: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(0, Argument, Right(a))
+    * scala> source.read(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(a))
     *
-    * scala> source.read(1)
-    * res1: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
+    * scala> source.read(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
     * }}}
     */
   def byIndex[V](keyType: ConfigKeyType[Int])(
@@ -640,11 +640,11 @@ object ConfigSource extends ConfigSourcePlatformSpecific {
     * scala> val source = ConfigSource.byIndexF[api.Id, String](ConfigKeyType.Argument)(Vector("a"))
     * source: ConfigSource[api.Id, Int, String] = ConfigSource(Argument)
     *
-    * scala> source.read(0)
-    * res0: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(0, Argument, Right(a))
+    * scala> source.read(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(a))
     *
-    * scala> source.read(1)
-    * res1: ConfigEntry[api.Id, Int, String, String] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
+    * scala> source.read(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
     * }}}
     */
   def byIndexF[F[_]: Apply, V](keyType: ConfigKeyType[Int])(

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -25,14 +25,15 @@ abstract class ConfigValue[F[_]: Apply, V] {
     * scala> val apiKey =
     *      |  env[String]("API_KEY").
     *      |    orElse(prop("api.key"))
-    * apiKey: ConfigValue[api.Id, String] = ConfigValue(Left(Combined(MissingKey(API_KEY, Environment), MissingKey(api.key, Property))))
+    * apiKey: ConfigValue[api.Id, String] = ConfigValue$$1815631407
     *
     * scala> apiKey.value.left.map(_.message).toString
     * res0: String = Left(Missing environment variable [API_KEY] and missing system property [api.key])
     *
     * scala> env[String]("FILE_ENCODING").
-    *      |   orElse(prop("file.encoding"))
-    * res1: ConfigValue[api.Id, String] = ConfigValue(Right(UTF8))
+    *      |   orElse(prop("file.encoding")).
+    *      |   toStringWithValue
+    * res1: String = ConfigValue(Right(UTF8))
     * }}}
     *
     * If the value is unavailable due to a different error than the
@@ -41,8 +42,9 @@ abstract class ConfigValue[F[_]: Apply, V] {
     *
     * {{{
     * scala> prop[Int]("file.encoding").
-    *      |   orElse(env("FILE_ENCODING"))
-    * res2: ConfigValue[api.Id, Int] = ConfigValue(Left(WrongType(file.encoding, Property, Right(UTF8), UTF8, Int, java.lang.NumberFormatException: For input string: "UTF8")))
+    *      |   orElse(env("FILE_ENCODING")).
+    *      |   toStringWithValue
+    * res2: String = ConfigValue(Left(WrongType(file.encoding, Property, Right(UTF8), UTF8, Int, java.lang.NumberFormatException: For input string: "UTF8")))
     * }}}
     *
     * Note that the alternative value is passed by reference, and it
@@ -75,8 +77,9 @@ abstract class ConfigValue[F[_]: Apply, V] {
     * {{{
     * scala> env[String]("API_KEY").
     *      |   orElse(prop("api.key")).
-    *      |   orNone
-    * res0: ConfigValue[api.Id,Option[String]] = ConfigValue(Right(None))
+    *      |   orNone.
+    *      |   toStringWithValue
+    * res0: String = ConfigValue(Right(None))
     * }}}
     *
     * If the value is unavailable due to a different error than the
@@ -84,8 +87,8 @@ abstract class ConfigValue[F[_]: Apply, V] {
     * not be replaced with `None`.
     *
     * {{{
-    * scala> prop[Int]("file.encoding").orNone
-    * res1: ConfigValue[api.Id, Option[Int]] = ConfigValue(Left(WrongType(file.encoding, Property, Right(UTF8), UTF8, Int, java.lang.NumberFormatException: For input string: "UTF8")))
+    * scala> prop[Int]("file.encoding").orNone.toStringWithValue
+    * res1: String = ConfigValue(Left(WrongType(file.encoding, Property, Right(UTF8), UTF8, Int, java.lang.NumberFormatException: For input string: "UTF8")))
     * }}}
     *
     * @return a new [[ConfigValue]]
@@ -102,11 +105,11 @@ abstract class ConfigValue[F[_]: Apply, V] {
     "ConfigValue$" + System.identityHashCode(this)
 
   /**
-    * Returns a [[String]] representation of this [[ConfigValue]]
+    * Returns a `String` representation of this [[ConfigValue]]
     * including the value. If the value is potentially sensitive,
     * then be careful to not include it in log output.
     *
-    * @return a [[String]] representation with the value
+    * @return a `String` representation with the value
     */
   def toStringWithValue: String =
     s"ConfigValue($value)"

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -108,7 +108,7 @@ abstract class ConfigValue[F[_]: Apply, V] {
     *
     * @return a [[String]] representation with the value
     */
-  final def toStringWithValue: String =
+  def toStringWithValue: String =
     s"ConfigValue($value)"
 
   private[ciris] final def append[A](next: ConfigValue[F, A]): ConfigValue2[F, V, A] = {

--- a/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigValue.scala
@@ -98,6 +98,19 @@ abstract class ConfigValue[F[_]: Apply, V] {
       }
     }
 
+  override def toString: String =
+    "ConfigValue$" + System.identityHashCode(this)
+
+  /**
+    * Returns a [[String]] representation of this [[ConfigValue]]
+    * including the value. If the value is potentially sensitive,
+    * then be careful to not include it in log output.
+    *
+    * @return a [[String]] representation with the value
+    */
+  final def toStringWithValue: String =
+    s"ConfigValue($value)"
+
   private[ciris] final def append[A](next: ConfigValue[F, A]): ConfigValue2[F, V, A] = {
     new ConfigValue2((this.value product next.value).map {
       case (Right(v), Right(a))         => Right((v, a))
@@ -135,7 +148,6 @@ object ConfigValue {
     val theValue = value
     new ConfigValue[F, V] {
       override def value: F[Either[ConfigError, V]] = theValue
-      override def toString: String = s"ConfigValue($value)"
     }
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/decoders/CirisConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/CirisConfigDecoders.scala
@@ -6,6 +6,8 @@ trait CirisConfigDecoders {
   implicit def secretConfigDecoder[A, B](
     implicit decoder: ConfigDecoder[A, B]
   ): ConfigDecoder[A, Secret[B]] = {
-    decoder.map(Secret.apply)
+    decoder
+      .map(Secret.apply)
+      .redactSensitive
   }
 }

--- a/modules/core/shared/src/main/scala/ciris/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/package.scala
@@ -22,8 +22,8 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * @tparam Value the type to convert the value to
     * @return a [[ConfigEntry]] with the result
     * @example {{{
-    * scala> ciris.env[Int]("key")
-    * res0: ciris.ConfigEntry[ciris.api.Id, String, String, Int] = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
+    * scala> ciris.env[Int]("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Environment, Left(MissingKey(key, Environment)))
     * }}}
     */
   def env[Value](key: String)(
@@ -71,8 +71,8 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * @tparam Value the type to convert the value to
     * @return a [[ConfigEntry]] with the result
     * @example {{{
-    * scala> ciris.prop[Int]("key")
-    * res0: ciris.ConfigEntry[ciris.api.Id, String, String, Int] = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
+    * scala> ciris.prop[Int]("key").toStringWithValues
+    * res0: String = ConfigEntry(key, Property, Left(MissingKey(key, Property)))
     * }}}
     */
   def prop[Value](key: String)(
@@ -124,14 +124,14 @@ package object ciris extends LoadConfigs with CirisPlatformSpecific {
     * @tparam Value the type to convert the value to
     * @return a [[ConfigEntry]] with the result
     * @example {{{
-    * scala> ciris.arg[Int](Array("50"))(0)
-    * res0: ciris.ConfigEntry[ciris.api.Id, Int, String, Int] = ConfigEntry(0, Argument, Right(50))
+    * scala> ciris.arg[Int](Array("50"))(0).toStringWithValues
+    * res0: String = ConfigEntry(0, Argument, Right(50))
     *
-    * scala> ciris.arg[Int](Array("50"))(1)
-    * res1: ciris.ConfigEntry[ciris.api.Id, Int, String, Int] = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
+    * scala> ciris.arg[Int](Array("50"))(1).toStringWithValues
+    * res1: String = ConfigEntry(1, Argument, Left(MissingKey(1, Argument)))
     *
-    * scala> ciris.arg[Int](Array("a"))(0)
-    * res2: ciris.ConfigEntry[ciris.api.Id, Int, String, Int] = ConfigEntry(0, Argument, Right(a), Left(WrongType(0, Argument, Right(a), a, Int, java.lang.NumberFormatException: For input string: "a")))
+    * scala> ciris.arg[Int](Array("a"))(0).toStringWithValues
+    * res2: String = ConfigEntry(0, Argument, Right(a), Left(WrongType(0, Argument, Right(a), a, Int, java.lang.NumberFormatException: For input string: "a")))
     * }}}
     */
   def arg[Value](args: IndexedSeq[String])(index: Int)(

--- a/modules/refined/jvm/src/main/scala/ciris/refined/syntax.scala
+++ b/modules/refined/jvm/src/main/scala/ciris/refined/syntax.scala
@@ -38,10 +38,10 @@ object syntax {
       * import eu.timepit.refined.collection.NonEmpty
       *
       * scala> val entry = ConfigEntry("key", ConfigKeyType.Property, Right("value"))
-      * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property, Right(value))
+      * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property)
       *
       * scala> entry.refineValue[NonEmpty]
-      * res0: ConfigEntry[api.Id, String, String, Refined[String, NonEmpty]] = ConfigEntry(key, Property, Right(value))
+      * res0: ConfigEntry[api.Id, String, String, Refined[String, NonEmpty]] = ConfigEntry(key, Property)
       * }}}
       */
     def refineValue[P](
@@ -94,10 +94,10 @@ object syntax {
       * import eu.timepit.refined.string.Uri
       *
       * scala> val host = ConfigEntry("key", ConfigKeyType.Property, Right("google.com"))
-      * host: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property, Right(google.com))
+      * host: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Property)
       *
-      * scala> val api = host.mapRefineValue[Uri](_ + "/api")
-      * api: ConfigEntry[api.Id, String, String, Refined[String, Uri]] = ConfigEntry(key, Property, Right(google.com))
+      * scala> host.mapRefineValue[Uri](_ + "/api")
+      * res0: ConfigEntry[api.Id, String, String, Refined[String, Uri]] = ConfigEntry(key, Property)
       * }}}
       */
     def mapRefineValue[P]: MapRefineValuePartiallyApplied[F, K, S, V, P] =

--- a/tests/shared/src/test/scala/ciris/ConfigDecoderSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigDecoderSpec.scala
@@ -170,5 +170,13 @@ final class ConfigDecoderSpec extends PropertySpec {
         }
       }
     }
+
+    "using redactSensitive" should {
+      "redact sensitive error messages" in {
+        val decoder = ConfigDecoder[String].mapCatchNonFatal("Int")(_.toInt)
+        val decoded = decoder.redactSensitive.decode(existingEntry("abc"))
+        decoded.left.map(_.message) shouldBe Left("Test key [key] with value [<redacted>] cannot be converted to type [Int]")
+      }
+    }
   }
 }

--- a/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
@@ -13,6 +13,15 @@ final class ConfigEntrySpec extends PropertySpec {
       }
     }
 
+    "using toStringWithValue" should {
+      "include the value" in {
+        forAll { value: String =>
+          existingEntry(value).toStringWithValue shouldBe
+            s"ConfigEntry(key, ConfigKeyType(test key), Right($value))"
+        }
+      }
+    }
+
     "using toStringWithValues" should {
       "include the key, keyType, and value" in {
         forAll { value: String =>

--- a/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigEntrySpec.scala
@@ -4,10 +4,19 @@ import ciris.api._
 
 final class ConfigEntrySpec extends PropertySpec {
   "ConfigEntry" when {
-    "converting to String" should {
-      "include the key, keyType, and value" in {
+    "using toString" should {
+      "include the key and keyType" in {
         forAll { value: String =>
           existingEntry(value).toString shouldBe
+            s"ConfigEntry(key, ConfigKeyType(test key))"
+        }
+      }
+    }
+
+    "using toStringWithValues" should {
+      "include the key, keyType, and value" in {
+        forAll { value: String =>
+          existingEntry(value).toStringWithValues shouldBe
             s"ConfigEntry(key, ConfigKeyType(test key), Right($value))"
         }
       }
@@ -16,7 +25,7 @@ final class ConfigEntrySpec extends PropertySpec {
         forAll { value: String =>
           existingEntry(value)
             .mapValue(_ + "2")
-            .toString shouldBe {
+            .toStringWithValues shouldBe {
             s"ConfigEntry(key, ConfigKeyType(test key), Right($value), Right(${value}2))"
           }
         }

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -11,8 +11,12 @@ final class ConfigValueSpec extends PropertySpec {
         ConfigValue(Right(123)).value shouldBe Right(123)
       }
 
-      "have the expected string representation" in {
-        ConfigValue(Right(123)).toString shouldBe "ConfigValue(Right(123))"
+      "include the value in toStringWithValue" in {
+        ConfigValue(Right(123)).toStringWithValue shouldBe "ConfigValue(Right(123))"
+      }
+
+      "not include the value in toString" in {
+        ConfigValue(Right(123)).toString.contains("123") shouldBe false
       }
     }
 
@@ -21,8 +25,12 @@ final class ConfigValueSpec extends PropertySpec {
         ConfigValue.applyF[Id, Int](right(123)).value shouldBe Right(123)
       }
 
-      "have the expected string representation" in {
-        ConfigValue.applyF[Id, Int](right(123)).toString shouldBe "ConfigValue(Right(123))"
+      "include the value in toStringWithValue" in {
+        ConfigValue.applyF[Id, Int](right(123)).toStringWithValue shouldBe "ConfigValue(Right(123))"
+      }
+
+      "not include the value in toString" in {
+        ConfigValue.applyF[Id, Int](right(123)).toString.contains("123") shouldBe false
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
@@ -21,7 +21,7 @@ final class CirisInstancesForCatsSpec extends PropertySpec {
               List(Right("123"))
             )
             .mapValue(_.toInt)
-        ) shouldBe "ConfigEntry(key, ConfigKeyType(keyType), List(Right(123)))"
+        ) shouldBe "ConfigEntry(key, ConfigKeyType(keyType))"
 
         Show[ConfigEntry[List, String, String, Int]].show(
           ConfigEntry
@@ -31,11 +31,13 @@ final class CirisInstancesForCatsSpec extends PropertySpec {
             List(Right("123"))
           )
             .mapValue(s => (s + "4").toInt)
-        ) shouldBe "ConfigEntry(key, ConfigKeyType(keyType), List(Right(123)), List(Right(1234)))"
+        ) shouldBe "ConfigEntry(key, ConfigKeyType(keyType))"
+
+        val configValue = ConfigValue.applyF[List, Int](List(right(123)))
 
         Show[ConfigValue[List, Int]].show(
-          ConfigValue.applyF[List, Int](List(right(123)))
-        ) shouldBe "ConfigValue(List(Right(123)))"
+          configValue
+        ) shouldBe configValue.toString
 
         Show[_root_.ciris.api.Id[Int]]
           .show(123) shouldBe "123"

--- a/tests/shared/src/test/scala/ciris/decoders/CirisConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/decoders/CirisConfigDecodersSpec.scala
@@ -1,0 +1,15 @@
+package ciris.decoders
+
+import ciris.{ConfigDecoder, PropertySpec, Secret}
+
+final class CirisConfigDecodersSpec extends PropertySpec {
+  "CirisConfigDecodersSpec" when {
+    "decoding a Secret" should {
+      "redact error messages" in {
+        val decoded = ConfigDecoder[String, Secret[Int]].decode(existingEntry("abc"))
+        decoded.left.map(_.message) shouldBe Left("Test key [key] with value [<redacted>] cannot be converted to type [Int]")
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Hiding sensitive details**
- Change `ConfigValue#toString` and `ConfigEntry#toString` to not include values.
- Change `Show` instances for `ConfigValue` and `ConfigEntry` to not include values.
- Add `ConfigValue#toStringWithValue` and `ConfigEntry#toStringWithValues` for keeping the previous `toString` behaviours.

You'll no longer have to worry about accidentally logging values, unless you're explicitly logging the result from a function with `value` in the name (`sourceValue`, `value`, `toStringWithValue`, ...).

**Redacting sensitive details**
- Add `ConfigError#sensitive` for creating errors with sensitive details.
- Add `ConfigError#redactSensitive` for redacting sensitive details.
- Add `ConfigError#redactedValue` placeholder for redacted details.
- Add `ConfigDecoder#redactSensitive` for redacting sensitive details in decoding errors.
- Change `ConfigDecoder[Secret[A]]` to automatically redact sensitive details.
- Change `ConfigError#combined`, `missingKey`, `readException`, `wrongType` to redact sensitive details.

In effect, this means that if you're using `Secret` to wrap the types of your secret configuration values, sensitive details will now automatically be redacted in error messages. And you will not have to worry about ever accidentally including secret values in log output.

```scala
scala> env[Secret[Int]]("FILE_ENCODING")
     |  .orElse(prop("file.encoding"))
     |  .value.left.map(_.message)
res0: Either[String,ciris.Secret[Int]] = Left(Missing environment variable [FILE_ENCODING] and system property [file.encoding] with value [<redacted>] cannot be converted to type [Int])
```