### PR TITLE
Prevent generic decoding for Option

### DIFF
--- a/docs/src/main/tut/docs/generic-module.md
+++ b/docs/src/main/tut/docs/generic-module.md
@@ -5,7 +5,7 @@ permalink: /docs/generic-module
 ---
 
 # Generic Module
-The `ciris-generic` module provides the ability to decode products and coproducts using [shapeless][shapeless]. This allows you to decode case classes, [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless `Generic` supports. Note that this also includes constructs like `Option`, potentially overriding behaviour already defined in other modules.
+The `ciris-generic` module provides the ability to decode products and coproducts using [shapeless][shapeless]. This allows you to decode case classes, [value classes](http://docs.scala-lang.org/overviews/core/value-classes.html), and shapeless coproducts, plus anything else that shapeless `Generic` supports. Note that care has been taken to make sure the generic module does not override default behaviours defined in the core module. The generic module might still override other defined behaviours, so use with care.
 
 Let's take a look at some examples. We start by defining a source from which we can read configuration values.
 

--- a/modules/generic/shared/src/main/scala/ciris/generic/decoders/GenericConfigDecoders.scala
+++ b/modules/generic/shared/src/main/scala/ciris/generic/decoders/GenericConfigDecoders.scala
@@ -2,9 +2,9 @@ package ciris.generic.decoders
 
 import ciris.api._
 import ciris.api.syntax._
-import ciris.{ConfigError, ConfigDecoder, ConfigEntry}
+import ciris.{ConfigDecoder, ConfigEntry, ConfigError}
 import ciris.ConfigError.{left, right}
-import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
+import shapeless.{:+:, ::, <:!<, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
 
 trait GenericConfigDecoders {
   implicit def cNilConfigDecoder[A]: ConfigDecoder[A, CNil] =
@@ -64,9 +64,11 @@ trait GenericConfigDecoders {
     }
 
   implicit def genericConfigDecoder[A, B, C](
-    implicit gen: Generic.Aux[C, B],
+    implicit ev: C <:!< Option[_], // Do not override default behaviour for Option
+    gen: Generic.Aux[C, B],
     decodeB: Lazy[ConfigDecoder[A, B]]
   ): ConfigDecoder[A, C] = {
+    val _ = ev // Prevent unused warning
     decodeB.value.map(gen.from)
   }
 }

--- a/tests/shared/src/test/scala/ciris/generic/decoders/GenericConfigDecodersSpec.scala
+++ b/tests/shared/src/test/scala/ciris/generic/decoders/GenericConfigDecodersSpec.scala
@@ -1,10 +1,10 @@
 package ciris.generic.decoders
 
-import ciris.{ConfigDecoder, ConfigError, PropertySpec}
 import ciris.generic._
+import ciris.{ConfigDecoder, PropertySpec}
+import org.scalacheck.Gen
 import shapeless._
 import shapeless.test.illTyped
-import org.scalacheck.Gen
 
 final class FloatValue(val value: Float) extends AnyVal
 
@@ -189,6 +189,12 @@ final class GenericConfigDecodersSpec extends PropertySpec {
         forAll(Gen.alphaStr) { string =>
           readValue[TwoValues](string) shouldBe a [Left[_, _]]
         }
+      }
+    }
+
+    "reading an Option" should {
+      "not override the default behaviour" in {
+        readValue[Option[String]]("value") shouldBe Right(Some("value"))
       }
     }
   }


### PR DESCRIPTION
Before, the current behaviour of the generic module.

```scala
scala> import ciris._, ciris.generic._
import ciris._
import ciris.generic._

scala> prop[Option[String]]("file.encoding").value
res0: ciris.api.Id[Either[ciris.ConfigError,Option[String]]] = Right(None)
```

After, with the changes in this pull request.

```scala
scala> import ciris._, ciris.generic._
import ciris._
import ciris.generic._

scala> prop[Option[String]]("file.encoding").value
res0: ciris.api.Id[Either[ciris.ConfigError,Option[String]]] = Right(Some(UTF8))
```