### PR TITLE
Remove support for Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     - gh-pages
 language: scala
 scala:
-  - 2.10.7
   - 2.11.12
   - 2.12.6
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ import ReleaseTransformations._
 
 /* Variables */
 
-lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.6"
 
@@ -363,7 +362,7 @@ lazy val docs = project
 
 lazy val scalaSettings = Seq(
   scalaVersion := scala212,
-  crossScalaVersions := Seq(scala210, scala211, scala212),
+  crossScalaVersions := Seq(scala211, scala212),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
@@ -384,7 +383,6 @@ lazy val scalaSettings = Seq(
     "-Ywarn-unused-import",
     "-Ywarn-unused"
   ).filter {
-    case "-Ywarn-unused-import" if (scalaVersion.value startsWith "2.10") => false
     case "-Ywarn-unused" if !(scalaVersion.value startsWith "2.12") => false
     case _ => true
   },
@@ -484,13 +482,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val kindProjectorSettings = Seq(
-  addCompilerPlugin("org.spire-math" % "kind-projector" % kindProjectorVersion cross CrossVersion.binary),
-  libraryDependencies ++= (scalaBinaryVersion.value match {
-    case "2.10" =>
-      compilerPlugin("org.scalamacros" % "paradise" % macroParadiseVerison cross CrossVersion.full) :: Nil
-    case _ =>
-      Nil
-  })
+  addCompilerPlugin("org.spire-math" % "kind-projector" % kindProjectorVersion cross CrossVersion.binary)
 )
 
 lazy val jvmModuleSettings =

--- a/docs/src/main/tut/docs/contributing.md
+++ b/docs/src/main/tut/docs/contributing.md
@@ -80,12 +80,6 @@ Following is a step-by-step guide on how to add a new module.
 
    If the module won't support Scala.js or Scala Native, remove the unsupported platforms from `crossProject`, along with `jsSettings` and `nativeSettings`, and the `fooJS` and `fooNative` projects, respectively.
 
-   If the module won't support the default `crossScalaVersions` (Scala 2.10, 2.11, and 2.12), remove those versions from the project definition. Below is an example of how to remove support for Scala 2.10 (`scala210`, `scala211`, `scala212` are variables for the Scala versions used in the build).
-
-    ```scala
-    .settings(scalaSettings ++ Seq(crossScalaVersions -= scala210))
-    ```
-
    If the module has a dependency on another library, add the dependency version to the variables section:
 
     ```scala

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -109,22 +109,10 @@ For an explanation of how to use the modules, refer to the [modules overview](ht
 - The [`ciris-spire`][spire-module] module allows loading [spire][spire] number types.
 - The [`ciris-squants`][squants-module] module allows loading [squants][squants] data types.
 
-If you're using [`ciris-generic`][generic-module] with Scala 2.10, you'll need to include the [Macro Paradise](https://docs.scala-lang.org/overviews/macros/paradise.html) compiler plugin.
-
-```scala
-libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
-```
-
-If you're using [`ciris-cats`][cats-module] or [`ciris-cats-effect`][cats-effect-module] with Scala 2.11.9 or later, you should enable [partial unification](https://github.com/scala/bug/issues/2712):
+If you're using [`ciris-cats`][cats-module] or [`ciris-cats-effect`][cats-effect-module], you should enable [partial unification](https://github.com/scala/bug/issues/2712).
 
 ```scala
 scalacOptions += "-Ypartial-unification"
-```
-
-or, if you need to support Scala 2.10.6 or later, you can use the [sbt-partial-unification](https://github.com/fiadliel/sbt-partial-unification) plugin.
-
-```scala
-addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
 ```
 
 #### Ammonite

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -9,11 +9,15 @@ import ciris.build.info._
 def minorVersion(version: String): String =
   version.split('.').init.mkString(".")
 
-val scalaPublishVersions: Seq[String] =
-  crossScalaVersions.map(minorVersion)
+val scalaPublishVersions: List[String] =
+  crossScalaVersions.map(minorVersion).toList
 
-val scalaPublishVersionsString: String =
-  scalaPublishVersions.init.mkString(", ") ++ scalaPublishVersions.lastOption.map(", and " + _).mkString
+val scalaPublishVersionsString: String = scalaPublishVersions match {
+  case Nil               => ""
+  case one :: Nil        => one
+  case one :: two :: Nil => s"$one and $two"
+  case threeOrMore       => threeOrMore.init.mkString(", ") ++ ", and " ++ threeOrMore.last
+}
 
 val latestMinorVersion =
   minorVersion(latestVersion)

--- a/modules/core/shared/src/main/scala/ciris/decoders/MathConfigDecoders.scala
+++ b/modules/core/shared/src/main/scala/ciris/decoders/MathConfigDecoders.scala
@@ -1,8 +1,6 @@
 package ciris.decoders
 
 import java.math.{
-  MathContext,
-  RoundingMode,
   BigDecimal => JavaBigDecimal,
   BigInteger => JavaBigInteger
 }
@@ -15,19 +13,8 @@ trait MathConfigDecoders {
   implicit val bigIntConfigDecoder: ConfigDecoder[String, BigInt] =
     ConfigDecoder.catchNonFatal("BigInt")(BigInt(_))
 
-  implicit val bigDecimalConfigDecoder: ConfigDecoder[String, BigDecimal] = {
-    // Workaround loss of precision on Scala 2.10
-    def exact(d: JavaBigDecimal): BigDecimal =
-      new BigDecimal(
-        d, {
-          if (d.precision <= BigDecimal.defaultMathContext.getPrecision)
-            BigDecimal.defaultMathContext
-          else new MathContext(d.precision, RoundingMode.HALF_EVEN)
-        }
-      )
-
-    ConfigDecoder.catchNonFatal("BigDecimal")(s => exact(new JavaBigDecimal(s)))
-  }
+  implicit val bigDecimalConfigDecoder: ConfigDecoder[String, BigDecimal] =
+    ConfigDecoder.catchNonFatal("BigDecimal")(BigDecimal(_))
 
   implicit val javaBigDecimalConfigDecoder: ConfigDecoder[String, JavaBigDecimal] =
     ConfigDecoder.catchNonFatal("BigDecimal")(new JavaBigDecimal(_))


### PR DESCRIPTION
Some reasons for removing Scala 2.10 support:

- interest in Scala 2.10 is low: ~13.6% of total downloads last month were for 2.10 modules,
- a [sbt bug](https://github.com/sbt/sbt/issues/4181) prevents us from using libraries which are not published for Scala 2.10,
- increased maintenance burden, especially with Scala 2.13 coming up,
- only one external module, `ciris-kubernetes`, supports Scala 2.10,
- want to encourage people to move to newer Scala versions.