### PR TITLE
Include value short hash in Secret#toString

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val scala212 = "2.12.6"
 
 lazy val catsEffectVersion = "0.10.1"
 lazy val catsVersion = "1.1.0"
+lazy val commonsCodecVersion = "1.11"
 lazy val enumeratumVersion = "1.5.13"
 lazy val kindProjectorVersion = "0.9.7"
 lazy val kittensVersion = "1.1.0"
@@ -226,6 +227,7 @@ lazy val tests =
   crossProject(JSPlatform, JVMPlatform)
     .in(file("tests"))
     .settings(moduleName := "ciris-tests", name := "Ciris tests")
+    .settings(libraryDependencies += "commons-codec" % "commons-codec" % commonsCodecVersion % Test)
     .settings(libraryDependencies += compilerPlugin("org.scalamacros" % "paradise" % macroParadiseVerison % Test cross CrossVersion.patch))
     .settings(scalaSettings)
     .settings(noPublishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -489,7 +489,11 @@ lazy val kindProjectorSettings = Seq(
 )
 
 lazy val jvmModuleSettings =
-  mimaSettings
+  mimaSettings ++ Seq(
+    coverageExcludedPackages := List(
+      "ciris.internal.digest.GeneralDigest"
+    ).mkString(";")
+  )
 
 lazy val nonJvmModuleSettings = Seq(
   doctestGenTests := Seq.empty,

--- a/docs/src/main/tut/docs/basics.md
+++ b/docs/src/main/tut/docs/basics.md
@@ -97,12 +97,12 @@ env[String]("API_KEY").
   orNone
 ```
 
-It is also possible to read values with type [`Secret`][Secret], in order to prevent values from being output in logs.
+It is also possible to read values with type [`Secret`][Secret], in order to prevent values from being output in logs. The [`Secret`][Secret] `String` representation includes a short SHA1 hash of the value, so you can check that the expected value is being used.
 
 ```tut:book
 import ciris.Secret
 
-prop[Secret[Option[String]]]("api.key").value
+prop[Secret[String]]("file.encoding").value
 ```
 
 For more information on [`Secret`][Secret], refer to the [logging configurations](/docs/logging) section.

--- a/docs/src/main/tut/docs/logging.md
+++ b/docs/src/main/tut/docs/logging.md
@@ -5,7 +5,7 @@ permalink: /docs/logging
 ---
 
 # Logging Configurations
-Configuration logging can quickly help you determine which values are being used by the application, and can aid with debugging whenever things go wrong. Since configurations often contain secret values -- avoiding having secrets in code being one of the main use cases for configurations -- we would like to avoid having these secrets included in any logs. Ciris provides the [`Secret`][Secret] wrapper type for this purpose. By wrapping your secret configuration values in [`Secret`][Secret], we can avoid  accidentally including them in logs.
+Configuration logging can quickly help you determine which values are being used by the application, and can aid with debugging whenever things go wrong. Since configurations often contain secret values -- avoiding having secrets in code being one of the main use cases for configurations -- we would like to avoid having these secrets included in any logs. Ciris provides the [`Secret`][Secret] wrapper type for this purpose. By wrapping your secret configuration values in [`Secret`][Secret], we can avoid accidentally including them in logs.
 
 For example, let's take a look at the following configuration, where the `ApiKey` is secret. We're using refinement types to encode validation in the types of our values, refer to the [encoding validation](/docs/validation) section for more information. Note that the `ApiKey` in the example below would normally be loaded from, for example, a vault service -- unless the value itself is not considered a secret, for example, if it was used for testing purposes.
 
@@ -43,10 +43,17 @@ val config =
   )
 ```
 
-The perhaps easiest way to log the configuration is to use `println`. As you can see in the example below, the secret configuration value is replaced with a `Secret(***)` placeholder when printed, while the remaining values of the configuration are printed with their `toString` representations as expected.
+The perhaps easiest way to log the configuration is to use `println`. As you can see in the example below, the secret configuration value is replaced with a `Secret(0a7425a)` placeholder when printed, while the remaining values of the configuration are printed with their `toString` representations as expected.
 
 ```tut:book
 println(config)
+```
+
+The value `0a7425a` above is a short (first 7 characters) SHA1 hash of the value. This allows you to check whether the expected value is being used or not, without logging the actual value. To calculate the SHA1 short hash for a `String`, you can for example use [`sha1sum`][sha1sum].
+
+```bash
+❯ echo -n "RacrqvWjuu4KVmnTG9b6xyZMTP7jnX" | sha1sum | head -c 7
+0a7425a
 ```
 
 When loading configuration values with type [`Secret`][Secret], Ciris will make sure that no sensitive details are included in error messages. In general, potentially sensitive information is only included in results from functions with `value` in the name: for example, [`value`][ConfigEntry#value], [`sourceValue`][ConfigEntry#sourceValue], [`toStringWithValue`][ConfigEntry#toStringWithValue], and [`toStringWithValues`][ConfigEntry#toStringWithValues]. So make sure you are not accidentally logging the results from such functions.
@@ -103,6 +110,7 @@ implicit val showConfig: Show[Config] = {
 println(config.show)
 ```
 
+[sha1sum]: https://en.wikipedia.org/wiki/Sha1sum
 [Secret]: /api/ciris/Secret.html
 [kittens]: https://github.com/milessabin/kittens
 [Show]: https://typelevel.org/cats/typeclasses/show.html

--- a/modules/core/shared/src/main/scala/ciris/Secret.scala
+++ b/modules/core/shared/src/main/scala/ciris/Secret.scala
@@ -1,15 +1,22 @@
 package ciris
 
+import scala.annotation.tailrec
+
 /**
   * [[Secret]] is used to denote that a configuration value is secret, and
   * that it should not be included in any log output. By wrapping a value
-  * with `Secret`, the value will not be printed, but a `Secret(***)`
-  * placeholder will take its place.<br>
+  * with `Secret`, the value will not be printed, but a `Secret(hash)`
+  * placeholder will take its place, where `hash` is the SHA1 short
+  * hash of the value as a `String` in UTF-8. The short hash can
+  * be retrieved with [[valueShortHash]] and the full hash with
+  * [[valueHash]]. When decoding types wrapped with [[Secret]],
+  * sensitive details will automatically be redacted from
+  * error messages.<br>
   * <br>
   * To create a new `Secret`, use the apply method in the companion object.
   * {{{
   * scala> Secret(123)
-  * res0: Secret[Int] = Secret(***)
+  * res0: Secret[Int] = Secret(40bd001)
   * }}}
   *
   * The `equals`, `hashCode`, `copy`, and `unapply` methods are implemented.
@@ -18,10 +25,10 @@ package ciris
   * res1: Boolean = true
   *
   * scala> Secret(123).copy("abc")
-  * res2: Secret[String] = Secret(***)
+  * res2: Secret[String] = Secret(a9993e3)
   *
   * scala> Secret(123) match { case Secret(value) => Secret(value + 1) }
-  * res3: Secret[Int] = Secret(***)
+  * res3: Secret[Int] = Secret(f38cfe2)
   * }}}
   *
   * The original value can be retrieved; be careful to not include it in logs.
@@ -34,8 +41,39 @@ package ciris
   * @tparam A the type of the original value being wrapped
   */
 final class Secret[A] private (val value: A) {
+
+  /**
+    * Generates the SHA1 hash of the value as a `String` in UTF-8 encoding.
+    * The hash is returned in hex encoding and a short version, available
+    * from [[valueShortHash]] is used in [[toString]].
+    *
+    * @return the SHA1 hex hash of `value.toString` in UTF-8
+    */
+  def valueHash: String =
+    Secret.sha1Hex(value.toString)
+
+  /**
+    * Short version of [[valueHash]]. Only the first 7 characters are
+    * included. This short version of the hash is used in [[toString]].
+    *
+    * @return the first 7 characters of [[valueHash]]
+    */
+  def valueShortHash: String =
+    valueHash.take(7)
+
+  /**
+    * Generates a `String` representation which includes the short SHA1
+    * hash of the value as a `String`. By logging this hash, we can see
+    * whether it matches a pre-generated hash of the secret, and know
+    * that we're using the expected secret -- without logging the
+    * actual secret.
+    *
+    * @return a `String` representation containing [[valueShortHash]]
+    * @see [[valueShortHash]]
+    * @see [[valueHash]]
+    */
   override def toString: String =
-    "Secret(***)"
+    s"Secret($valueShortHash)"
 
   override def equals(that: Any): Boolean =
     that match {
@@ -56,4 +94,33 @@ object Secret {
 
   def unapply[A](secret: Secret[A]): Option[A] =
     Some(secret.value)
+
+  private[this] val hexChars: Array[Char] =
+    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
+
+  private def sha1Hex(s: String): String = {
+    def sha1(bytes: Array[Byte]): Array[Byte] = {
+      val digest = new internal.digest.SHA1Digest()
+      val hash = new Array[Byte](digest.digestSize)
+      digest.update(bytes, 0, bytes.length)
+      digest.doFinal(hash, 0)
+      hash
+    }
+
+    def hex(in: Array[Byte]): Array[Char] = {
+      val length = in.length
+
+      @tailrec def encode(out: Array[Char], i: Int, j: Int): Array[Char] = {
+        if (i < length) {
+          out(j) = hexChars((0xf0 & in(i)) >>> 4)
+          out(j + 1) = hexChars(0x0f & in(i))
+          encode(out, i + 1, j + 2)
+        } else out
+      }
+
+      encode(new Array(length << 1), 0, 0)
+    }
+
+    new String(hex(sha1(s.getBytes("UTF-8"))))
+  }
 }

--- a/modules/core/shared/src/main/scala/ciris/Secret.scala
+++ b/modules/core/shared/src/main/scala/ciris/Secret.scala
@@ -1,6 +1,6 @@
 package ciris
 
-import scala.annotation.tailrec
+import ciris.internal.digest.sha1Hex
 
 /**
   * [[Secret]] is used to denote that a configuration value is secret, and
@@ -50,7 +50,7 @@ final class Secret[A] private (val value: A) {
     * @return the SHA1 hex hash of `value.toString` in UTF-8
     */
   def valueHash: String =
-    Secret.sha1Hex(value.toString)
+    sha1Hex(value.toString)
 
   /**
     * Short version of [[valueHash]]. Only the first 7 characters are
@@ -94,33 +94,4 @@ object Secret {
 
   def unapply[A](secret: Secret[A]): Option[A] =
     Some(secret.value)
-
-  private[this] val hexChars: Array[Char] =
-    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
-
-  private def sha1Hex(s: String): String = {
-    def sha1(bytes: Array[Byte]): Array[Byte] = {
-      val digest = new internal.digest.SHA1Digest()
-      val hash = new Array[Byte](digest.digestSize)
-      digest.update(bytes, 0, bytes.length)
-      digest.doFinal(hash, 0)
-      hash
-    }
-
-    def hex(in: Array[Byte]): Array[Char] = {
-      val length = in.length
-
-      @tailrec def encode(out: Array[Char], i: Int, j: Int): Array[Char] = {
-        if (i < length) {
-          out(j) = hexChars((0xf0 & in(i)) >>> 4)
-          out(j + 1) = hexChars(0x0f & in(i))
-          encode(out, i + 1, j + 2)
-        } else out
-      }
-
-      encode(new Array(length << 1), 0, 0)
-    }
-
-    new String(hex(sha1(s.getBytes("UTF-8"))))
-  }
 }

--- a/modules/core/shared/src/main/scala/ciris/internal/digest/GeneralDigest.scala
+++ b/modules/core/shared/src/main/scala/ciris/internal/digest/GeneralDigest.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2000-2018 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package ciris.internal.digest
+
+private[digest] abstract class GeneralDigest {
+  private val xBuf: Array[Byte] = new Array(4)
+  private var xBufOff: Int = 0
+
+  private var byteCount: Long = 0L
+
+  def update(in: Byte): Unit = {
+    xBuf(xBufOff) = in
+    xBufOff += 1
+
+    if (xBufOff == xBuf.length) {
+      processWord(xBuf, 0)
+      xBufOff = 0
+    }
+
+    byteCount += 1
+  }
+
+  def update(in: Array[Byte], inOff: Int, len: Int): Unit = {
+    val length = Math.max(0, len)
+
+    //
+    // fill the current word
+    //
+    var i = 0
+    var done = false
+    if (xBufOff != 0) {
+      while (!done && i < length) {
+        xBuf(xBufOff) = in(inOff + i)
+        xBufOff += 1
+        i += 1
+
+        if (xBufOff == 4) {
+          processWord(xBuf, 0)
+          xBufOff = 0
+          done = true
+        }
+      }
+    }
+
+    //
+    // process whole words.
+    //
+    val limit = ((length - i) & ~3) + i
+    while (i < limit) {
+      processWord(in, inOff + i)
+      i += 4
+    }
+
+    //
+    // load in the remainder.
+    //
+    while (i < length) {
+      xBuf(xBufOff) = in(inOff + i)
+      xBufOff += 1
+      i += 1
+    }
+
+    byteCount += length
+  }
+
+  def finish(): Unit = {
+    val bitLength = byteCount << 3
+    //
+    // add the pad bytes.
+    //
+    update(128.toByte)
+    while (xBufOff != 0) update(0.toByte)
+    processLength(bitLength)
+    processBlock()
+  }
+
+  def reset(): Unit = {
+    byteCount = 0
+    xBufOff = 0
+    var i = 0
+    while (i < xBuf.length) {
+      xBuf(i) = 0
+      i += 1
+    }
+  }
+
+  protected def processWord(in: Array[Byte], inOff: Int): Unit
+
+  protected def processLength(bitLength: Long): Unit
+
+  protected def processBlock(): Unit
+}

--- a/modules/core/shared/src/main/scala/ciris/internal/digest/Pack.scala
+++ b/modules/core/shared/src/main/scala/ciris/internal/digest/Pack.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2000-2018 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package ciris.internal.digest
+
+private[digest] object Pack {
+  def intToBigEndian(n: Int, bs: Array[Byte], off: Int): Unit = {
+    bs(off) = (n >>> 24).toByte
+    bs(off + 1) = (n >>> 16).toByte
+    bs(off + 2) = (n >>> 8).toByte
+    bs(off + 3) = n.toByte
+  }
+}

--- a/modules/core/shared/src/main/scala/ciris/internal/digest/SHA1Digest.scala
+++ b/modules/core/shared/src/main/scala/ciris/internal/digest/SHA1Digest.scala
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2000-2018 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package ciris.internal.digest
+
+import ciris.internal.digest.SHA1Digest._
+
+private[ciris] final class SHA1Digest extends GeneralDigest {
+  private var H1, H2, H3, H4, H5: Int = 0
+
+  private val X: Array[Int] = new Array(80)
+  private var xOff: Int = 0
+
+  reset()
+
+  def digestSize: Int =
+    digestLength
+
+  override protected def processWord(in: Array[Byte], inOff: Int): Unit = {
+    // Note: Inlined for performance
+    //       X(xOff) = Pack.bigEndianToInt(in, inOff)
+    var off = inOff
+    var n = in(off) << 24
+    n |= (in({ off += 1; off }) & 0xff) << 16
+    n |= (in({ off += 1; off }) & 0xff) << 8
+    n |= (in({ off += 1; off }) & 0xff)
+    X(xOff) = n
+    xOff += 1
+    if (xOff == 16) processBlock()
+  }
+
+  override protected def processLength(bitLength: Long): Unit = {
+    if (xOff > 14) processBlock()
+    X(14) = (bitLength >>> 32).toInt
+    X(15) = bitLength.toInt
+  }
+
+  def doFinal(out: Array[Byte], outOff: Int): Int = {
+    finish()
+
+    Pack.intToBigEndian(H1, out, outOff)
+    Pack.intToBigEndian(H2, out, outOff + 4)
+    Pack.intToBigEndian(H3, out, outOff + 8)
+    Pack.intToBigEndian(H4, out, outOff + 12)
+    Pack.intToBigEndian(H5, out, outOff + 16)
+
+    reset()
+
+    SHA1Digest.digestLength
+  }
+
+  override def reset(): Unit = {
+    super.reset()
+
+    H1 = 0x67452301
+    H2 = 0xefcdab89
+    H3 = 0x98badcfe
+    H4 = 0x10325476
+    H5 = 0xc3d2e1f0
+
+    xOff = 0
+    var i = 0
+    while (i != X.length) {
+      X(i) = 0
+      i += 1
+    }
+  }
+
+  private def f(u: Int, v: Int, w: Int): Int =
+    (u & v) | (~u & w)
+
+  private def h(u: Int, v: Int, w: Int): Int =
+    u ^ v ^ w
+
+  private def g(u: Int, v: Int, w: Int): Int =
+    (u & v) | (u & w) | (v & w)
+
+  override protected def processBlock(): Unit = {
+    //
+    // expand 16 word block into 80 word block.
+    //
+    var i = 16
+    while (i < 80) {
+      val t = X(i - 3) ^ X(i - 8) ^ X(i - 14) ^ X(i - 16)
+      X(i) = t << 1 | t >>> 31
+      i += 1
+    }
+
+    //
+    // set up working variables.
+    //
+    var A = H1
+    var B = H2
+    var C = H3
+    var D = H4
+    var E = H5
+
+    //
+    // round 1
+    //
+    var idx = 0
+
+    var j = 0
+    while (j < 4) {
+      // E = rotateLeft(A, 5) + f(B, C, D) + E + X[idx++] + Y1
+      // B = rotateLeft(B, 30)
+      E += (A << 5 | A >>> 27) + f(B, C, D) + X(idx) + Y1
+      B = B << 30 | B >>> 2
+      idx += 1
+
+      D += (E << 5 | E >>> 27) + f(A, B, C) + X(idx) + Y1
+      A = A << 30 | A >>> 2
+      idx += 1
+
+      C += (D << 5 | D >>> 27) + f(E, A, B) + X(idx) + Y1
+      E = E << 30 | E >>> 2
+      idx += 1
+
+      B += (C << 5 | C >>> 27) + f(D, E, A) + X(idx) + Y1
+      D = D << 30 | D >>> 2
+      idx += 1
+
+      A += (B << 5 | B >>> 27) + f(C, D, E) + X(idx) + Y1
+      C = C << 30 | C >>> 2
+      idx += 1
+
+      j += 1
+    }
+
+    //
+    // round 2
+    //
+    j = 0
+    while (j < 4) {
+      // E = rotateLeft(A, 5) + h(B, C, D) + E + X[idx++] + Y2
+      // B = rotateLeft(B, 30)
+      E += (A << 5 | A >>> 27) + h(B, C, D) + X(idx) + Y2
+      B = B << 30 | B >>> 2
+      idx += 1
+
+      D += (E << 5 | E >>> 27) + h(A, B, C) + X(idx) + Y2
+      A = A << 30 | A >>> 2
+      idx += 1
+
+      C += (D << 5 | D >>> 27) + h(E, A, B) + X(idx) + Y2
+      E = E << 30 | E >>> 2
+      idx += 1
+
+      B += (C << 5 | C >>> 27) + h(D, E, A) + X(idx) + Y2
+      D = D << 30 | D >>> 2
+      idx += 1
+
+      A += (B << 5 | B >>> 27) + h(C, D, E) + X(idx) + Y2
+      C = C << 30 | C >>> 2
+      idx += 1
+
+      j += 1
+    }
+
+    //
+    // round 3
+    //
+    j = 0
+    while (j < 4) {
+      // E = rotateLeft(A, 5) + g(B, C, D) + E + X[idx++] + Y3
+      // B = rotateLeft(B, 30)
+      E += (A << 5 | A >>> 27) + g(B, C, D) + X(idx) + Y3
+      B = B << 30 | B >>> 2
+      idx += 1
+
+      D += (E << 5 | E >>> 27) + g(A, B, C) + X(idx) + Y3
+      A = A << 30 | A >>> 2
+      idx += 1
+
+      C += (D << 5 | D >>> 27) + g(E, A, B) + X(idx) + Y3
+      E = E << 30 | E >>> 2
+      idx += 1
+
+      B += (C << 5 | C >>> 27) + g(D, E, A) + X(idx) + Y3
+      D = D << 30 | D >>> 2
+      idx += 1
+
+      A += (B << 5 | B >>> 27) + g(C, D, E) + X(idx) + Y3
+      C = C << 30 | C >>> 2
+      idx += 1
+
+      j += 1
+    }
+
+    //
+    // round 4
+    //
+    j = 0
+    while (j <= 3) {
+      // E = rotateLeft(A, 5) + h(B, C, D) + E + X[idx++] + Y4
+      // B = rotateLeft(B, 30)
+      E += (A << 5 | A >>> 27) + h(B, C, D) + X(idx) + Y4
+      B = B << 30 | B >>> 2
+      idx += 1
+
+      D += (E << 5 | E >>> 27) + h(A, B, C) + X(idx) + Y4
+      A = A << 30 | A >>> 2
+      idx += 1
+
+      C += (D << 5 | D >>> 27) + h(E, A, B) + X(idx) + Y4
+      E = E << 30 | E >>> 2
+      idx += 1
+
+      B += (C << 5 | C >>> 27) + h(D, E, A) + X(idx) + Y4
+      D = D << 30 | D >>> 2
+      idx += 1
+
+      A += (B << 5 | B >>> 27) + h(C, D, E) + X(idx) + Y4
+      C = C << 30 | C >>> 2
+      idx += 1
+
+      j += 1
+    }
+
+    H1 += A
+    H2 += B
+    H3 += C
+    H4 += D
+    H5 += E
+
+    //
+    // reset start of the buffer.
+    //
+    xOff = 0
+    i = 0
+    while (i < 16) {
+      X(i) = 0
+      i += 1
+    }
+  }
+}
+
+private object SHA1Digest {
+  val digestLength: Int = 20
+
+  //
+  // Additive constants
+  //
+  val Y1 = 0x5a827999
+  val Y2 = 0x6ed9eba1
+  val Y3 = 0x8f1bbcdc
+  val Y4 = 0xca62c1d6
+}

--- a/modules/core/shared/src/main/scala/ciris/internal/digest/SHA1Digest.scala
+++ b/modules/core/shared/src/main/scala/ciris/internal/digest/SHA1Digest.scala
@@ -22,7 +22,7 @@ package ciris.internal.digest
 
 import ciris.internal.digest.SHA1Digest._
 
-private[ciris] final class SHA1Digest extends GeneralDigest {
+private[digest] final class SHA1Digest extends GeneralDigest {
   private var H1, H2, H3, H4, H5: Int = 0
 
   private val X: Array[Int] = new Array(80)

--- a/modules/core/shared/src/main/scala/ciris/internal/digest/package.scala
+++ b/modules/core/shared/src/main/scala/ciris/internal/digest/package.scala
@@ -1,0 +1,36 @@
+package ciris.internal
+
+import ciris.internal
+
+import scala.annotation.tailrec
+
+package object digest {
+  private[this] val hexChars: Array[Char] =
+    Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
+
+  private[ciris] def sha1Hex(s: String): String = {
+    def sha1(bytes: Array[Byte]): Array[Byte] = {
+      val digest = new internal.digest.SHA1Digest()
+      val hash = new Array[Byte](digest.digestSize)
+      digest.update(bytes, 0, bytes.length)
+      digest.doFinal(hash, 0)
+      hash
+    }
+
+    def hex(in: Array[Byte]): Array[Char] = {
+      val length = in.length
+
+      @tailrec def encode(out: Array[Char], i: Int, j: Int): Array[Char] = {
+        if (i < length) {
+          out(j) = hexChars((0xf0 & in(i)) >>> 4)
+          out(j + 1) = hexChars(0x0f & in(i))
+          encode(out, i + 1, j + 2)
+        } else out
+      }
+
+      encode(new Array(length << 1), 0, 0)
+    }
+
+    new String(hex(sha1(s.getBytes("UTF-8"))))
+  }
+}

--- a/tests/jvm/src/test/scala/ciris/SecretJvmSpec.scala
+++ b/tests/jvm/src/test/scala/ciris/SecretJvmSpec.scala
@@ -1,0 +1,13 @@
+package ciris
+
+import org.apache.commons.codec.digest.DigestUtils.sha1Hex
+
+final class SecretJvmSpec extends JvmPropertySpec {
+  "Secret" should {
+    "calculate the expected hash" in {
+      forAll { s: String =>
+        Secret(s).valueHash shouldBe sha1Hex(s)
+      }
+    }
+  }
+}

--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -16,7 +16,7 @@ final class ConfigValueSpec extends PropertySpec {
       }
 
       "not include the value in toString" in {
-        ConfigValue(Right(123)).toString.contains("123") shouldBe false
+        ConfigValue(Right(123)).toString shouldNot be ("ConfigValue(123)")
       }
     }
 
@@ -30,7 +30,7 @@ final class ConfigValueSpec extends PropertySpec {
       }
 
       "not include the value in toString" in {
-        ConfigValue.applyF[Id, Int](right(123)).toString.contains("123") shouldBe false
+        ConfigValue.applyF[Id, Int](right(123)).toString shouldNot be ("ConfigValue(123)")
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/SecretSpec.scala
+++ b/tests/shared/src/test/scala/ciris/SecretSpec.scala
@@ -1,6 +1,5 @@
 package ciris
 
-import org.apache.commons.codec.digest.DigestUtils.sha1Hex
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -9,12 +8,6 @@ final class SecretSpec extends PropertySpec {
     "use the short hash when represented as a string" in {
       forAll { secret: Secret[Int] =>
         secret.toString shouldBe s"Secret(${secret.valueShortHash})"
-      }
-    }
-
-    "calculate the expected hash" in {
-      forAll { secret: Secret[String] =>
-        secret.valueHash shouldBe sha1Hex(secret.value.toString.getBytes("UTF-8"))
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/SecretSpec.scala
+++ b/tests/shared/src/test/scala/ciris/SecretSpec.scala
@@ -1,13 +1,20 @@
 package ciris
 
+import org.apache.commons.codec.digest.DigestUtils.sha1Hex
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
 final class SecretSpec extends PropertySpec {
   "Secret" should {
-    "use a placeholder when represented as a string" in {
+    "use the short hash when represented as a string" in {
       forAll { secret: Secret[Int] =>
         secret.toString shouldBe s"Secret(${secret.valueShortHash})"
+      }
+    }
+
+    "calculate the expected hash" in {
+      forAll { secret: Secret[String] =>
+        secret.valueHash shouldBe sha1Hex(secret.value.toString.getBytes("UTF-8"))
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/SecretSpec.scala
+++ b/tests/shared/src/test/scala/ciris/SecretSpec.scala
@@ -7,7 +7,7 @@ final class SecretSpec extends PropertySpec {
   "Secret" should {
     "use a placeholder when represented as a string" in {
       forAll { secret: Secret[Int] =>
-        secret.toString shouldBe "Secret(***)"
+        secret.toString shouldBe s"Secret(${secret.valueShortHash})"
       }
     }
 

--- a/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
@@ -72,7 +72,7 @@ final class CirisInstancesForCatsSpec extends PropertySpec {
 
         Show[Secret[Int]].show(
           Secret(123)
-        ) shouldBe "Secret(***)"
+        ) shouldBe "Secret(40bd001)"
       }
     }
   }


### PR DESCRIPTION
- Add minified Bouncy Castle SHA1 implementation translated to Scala. We cannot use `java.security.MessageDigest` as it is not yet available on Scala.js or Scala Native.
  We can't use the Bouncy Castle Java implementation directly for the same reason.
- Change `Secret#toString` to include short SHA1 hash (first 7 characters) of value.
- Add `Secret#valueShortHash` and `Secret#valueHash` to be able to retrieve hashes.