### PR TITLE
Add a combine method to ConfigErrors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,6 +347,7 @@ lazy val docs = project
     ),
     crossScalaVersions := Seq(scalaVersion.value),
     scalacOptions --= Seq("-Xlint", "-Ywarn-unused", "-Ywarn-unused-import"),
+    scalacOptions += "-Ypartial-unification",
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(noDocumentationModules: _*),
     siteSubdirName in ScalaUnidoc := micrositeDocumentationUrl.value,
     addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc),

--- a/docs/src/main/tut/docs/cats-module.md
+++ b/docs/src/main/tut/docs/cats-module.md
@@ -44,7 +44,61 @@ val config = Await.result(futureConfig, 1.second)
 
 The `ciris-cats` module also provides [`Show`][Show] type class instances for [logging configurations](/docs/logging#logging-improvements).
 
+## Compositional loading of configuration using `parMapN`
+
+The `ciris-cats` module provides a [`Semigroup`][Semigroup] instance for
+`ConfigErrors`, because two lists of errors can be combined by concatenating
+them.
+
+This means that you can load small parts of your configuration using
+`loadConfig` and then compose the results together using `parMapN`.
+
+If any of the smaller configs failed to load, the final result will be a
+`ConfigErrors` containing all the error messages.
+
+Let's look at an example.
+
+Our app needs to talk to a database and an external API, so its configuration
+includes DB credentials and an API key. We have separate case classes for the
+different types of configuration.
+
+```tut:silent
+case class DbConfig(user: String, password: String)
+case class ApiClientConfig(apiKey: String)
+case class AppConfig(db: DbConfig, api: ApiClientConfig)
+```
+
+We load each of the configurations using `loadConfig`:
+
+```tut:invisible
+sys.props.put("db.user", "myapp")
+sys.props.put("db.password", "secretsauce")
+sys.props.put("api.key", "abc123")
+```
+
+```tut:book
+val dbConfig: Either[ConfigErrors, DbConfig] =
+  loadConfig(
+    prop[String]("db.user"),
+    prop[String]("db.password")
+  )(DbConfig.apply)
+
+val apiConfig: Either[ConfigErrors, ApiClientConfig] =
+  loadConfig(prop[String]("api.key"))(ApiClientConfig.apply)
+```
+
+We can then compose the results into an `Either[ConfigErrors, AppConfig]`:
+
+```tut:book
+import _root_.cats.instances.parallel._
+import _root_.cats.syntax.parallel._
+import ciris.cats._
+
+(dbConfig, apiConfig).parMapN(AppConfig.apply)
+```
+
 [ConfigSource]: /api/ciris/ConfigSource.html
 [Show]: https://typelevel.org/cats/typeclasses/show.html
+[Semigroup]: https://typelevel.org/cats/typeclasses/semigroup.html
 [cats]: https://github.com/typelevel/cats
 [Id]: /api/ciris/api/index.html#Id[A]=A

--- a/docs/src/main/tut/docs/logging.md
+++ b/docs/src/main/tut/docs/logging.md
@@ -85,7 +85,7 @@ import cats.Show
 import cats.derived._
 import cats.implicits._
 import ciris.cats._
-import eu.timepit.refined.cats._
+import eu.timepit.refined.cats.refTypeShow
 
 implicit val showConfig: Show[Config] = {
   import auto.show._

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
@@ -1,7 +1,6 @@
 package ciris.cats.api
 
 import cats.Show
-import cats.Semigroup
 import ciris._
 
 trait CirisInstancesForCats {
@@ -31,9 +30,4 @@ trait CirisInstancesForCats {
 
   implicit def showSecret[A]: Show[Secret[A]] =
     Show.fromToString
-
-  implicit val semigroupConfigErrors: Semigroup[ConfigErrors] = new Semigroup[ConfigErrors] {
-    def combine(first: ConfigErrors, second: ConfigErrors) =
-      ConfigErrors.combine(first, second)
-  }
 }

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCats.scala
@@ -1,6 +1,7 @@
 package ciris.cats.api
 
 import cats.Show
+import cats.Semigroup
 import ciris._
 
 trait CirisInstancesForCats {
@@ -30,4 +31,9 @@ trait CirisInstancesForCats {
 
   implicit def showSecret[A]: Show[Secret[A]] =
     Show.fromToString
+
+  implicit val semigroupConfigErrors: Semigroup[ConfigErrors] = new Semigroup[ConfigErrors] {
+    def combine(first: ConfigErrors, second: ConfigErrors) =
+      ConfigErrors.combine(first, second)
+  }
 }

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCatsBinCompat.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCatsBinCompat.scala
@@ -4,8 +4,7 @@ import cats.Semigroup
 import ciris._
 
 trait CirisInstancesForCatsBinCompat {
-  implicit val semigroupConfigErrors: Semigroup[ConfigErrors] = new Semigroup[ConfigErrors] {
-    def combine(first: ConfigErrors, second: ConfigErrors) =
-      ConfigErrors.combine(first, second)
-  }
+
+  implicit val semigroupConfigErrors: Semigroup[ConfigErrors] =
+    Semigroup.instance(_ combine _)
 }

--- a/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCatsBinCompat.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/api/CirisInstancesForCatsBinCompat.scala
@@ -1,0 +1,11 @@
+package ciris.cats.api
+
+import cats.Semigroup
+import ciris._
+
+trait CirisInstancesForCatsBinCompat {
+  implicit val semigroupConfigErrors: Semigroup[ConfigErrors] = new Semigroup[ConfigErrors] {
+    def combine(first: ConfigErrors, second: ConfigErrors) =
+      ConfigErrors.combine(first, second)
+  }
+}

--- a/modules/cats/shared/src/main/scala/ciris/cats/package.scala
+++ b/modules/cats/shared/src/main/scala/ciris/cats/package.scala
@@ -1,8 +1,8 @@
 package ciris
 
-import ciris.cats.api.{CatsInstancesForCiris, CirisInstancesForCats}
+import ciris.cats.api.{CatsInstancesForCiris, CirisInstancesForCats, CirisInstancesForCatsBinCompat}
 
 /**
   * Module providing an integration with [[https://github.com/typelevel/cats cats]].
   */
-package object cats extends CatsInstancesForCiris with CirisInstancesForCats
+package object cats extends CatsInstancesForCiris with CirisInstancesForCats with CirisInstancesForCatsBinCompat

--- a/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
@@ -81,6 +81,20 @@ final class ConfigErrors private (val toVector: Vector[ConfigError]) extends Any
     new ConfigErrors(toVector :+ error)
 
   /**
+   * Creates a new [[ConfigErrors]] instance containing all the errors of
+   * both `this` and `other`, in that order.
+   *
+   * @param other the other [[ConfigErrors]]
+    * @return a new [[ConfigErrors]] instance
+    * @example {{{
+    * scala> ConfigErrors(ConfigError("error1")).combine(ConfigErrors(ConfigError("error2")))
+    * res0: ConfigErrors = ConfigErrors(ConfigError(error1), ConfigError(error2))
+    * }}}
+   */
+  def combine(other: ConfigErrors): ConfigErrors =
+    new ConfigErrors(this.toVector ++ other.toVector)
+
+  /**
     * Returns the error messages of the errors in this [[ConfigErrors]].
     * The messages are guaranteed to be in the same order as the errors.
     *
@@ -170,20 +184,5 @@ object ConfigErrors {
     */
   def right[A](value: A): Either[ConfigErrors, A] =
     Right(value)
-
-  /**
-   * Creates a new [[ConfigErrors]] instance containing all the errors of
-   * both `first` and `second`, in that order.
-   *
-   * @param first the first [[ConfigErrors]]
-   * @param second the second [[ConfigErrors]]
-    * @return a new [[ConfigErrors]] instance
-    * @example {{{
-    * scala> ConfigErrors.combine(ConfigErrors(ConfigError("error1")), ConfigErrors(ConfigError("error2")))
-    * res0: ConfigErrors = ConfigErrors(ConfigError(error1), ConfigError(error2))
-    * }}}
-   */
-  def combine(first: ConfigErrors, second: ConfigErrors): ConfigErrors =
-    new ConfigErrors(first.toVector ++ second.toVector)
 
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigErrors.scala
@@ -170,4 +170,20 @@ object ConfigErrors {
     */
   def right[A](value: A): Either[ConfigErrors, A] =
     Right(value)
+
+  /**
+   * Creates a new [[ConfigErrors]] instance containing all the errors of
+   * both `first` and `second`, in that order.
+   *
+   * @param first the first [[ConfigErrors]]
+   * @param second the second [[ConfigErrors]]
+    * @return a new [[ConfigErrors]] instance
+    * @example {{{
+    * scala> ConfigErrors.combine(ConfigErrors(ConfigError("error1")), ConfigErrors(ConfigError("error2")))
+    * res0: ConfigErrors = ConfigErrors(ConfigError(error1), ConfigError(error2))
+    * }}}
+   */
+  def combine(first: ConfigErrors, second: ConfigErrors): ConfigErrors =
+    new ConfigErrors(first.toVector ++ second.toVector)
+
 }

--- a/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
+++ b/tests/shared/src/test/scala/ciris/cats/api/CirisInstancesForCatsSpec.scala
@@ -75,5 +75,20 @@ final class CirisInstancesForCatsSpec extends PropertySpec {
         ) shouldBe "Secret(40bd001)"
       }
     }
+
+    "providing Semigroup instances" should {
+      "be able to provide all required instances" in {
+        import _root_.cats.Semigroup
+        import _root_.cats.implicits._
+        import ciris._
+        import ciris.api._
+        import ciris.cats._
+
+        val first = ConfigErrors(ConfigError("a"), ConfigError("b"))
+        val second = ConfigErrors(ConfigError("c"), ConfigError("d"))
+        val combined = Semigroup[ConfigErrors].combine(first, second)
+        combined.messages shouldBe ConfigErrors(ConfigError("a"), ConfigError("b"), ConfigError("c"), ConfigError("d")).messages
+      }
+    }
   }
 }


### PR DESCRIPTION
Having a cats Semigroup is quite handy, as it means you can do a bunch of `loadConfig`s for small parts of your configuration and then `parMapN` them together [like this](https://github.com/ovotech/shipit/blob/5ee7d6536c17f83bf5280798d4f66906e6e6db6a/app/Config.scala#L110-L118).