### PR TITLE
Add ConfigValue#orValue

### DIFF
--- a/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/tests/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -108,5 +108,36 @@ final class ConfigValueSpec extends PropertySpec {
           .value shouldBe Right(Some("value"))
       }
     }
+
+    "using orValue" should {
+      "use value for a missing key" in {
+        readNonExistingConfigEntry[String]
+          .orValue("value")
+          .value shouldBe Right("value")
+      }
+
+      "use value for combined missing keys" in {
+        readNonExistingConfigEntry[String]
+          .orElse(readNonExistingConfigEntry)
+          .orValue("value")
+          .value shouldBe Right("value")
+      }
+
+      "keep an error that is not a missing key" in {
+        ConfigValue(ConfigError.left[String](ConfigError("error")))
+          .orValue("value")
+          .value
+          .left.map(_.message) shouldBe Left("error")
+      }
+
+      "keep a combined error that is not only missing keys" in {
+        readNonExistingConfigEntry[String]
+          .orElse(ConfigValue(ConfigError.left(ConfigError("error"))))
+          .orValue("value")
+          .value
+          .left
+          .map(_.message) shouldBe Left("Missing test key [key] and error")
+      }
+    }
   }
 }


### PR DESCRIPTION
This is mostly useful when entire `case class`es are loaded from the environment, as it saves you from having to decode as `Option` and use `getOrElse`.

Example, before:

```scala
final case class Config(
  a: String,
  b: String
)

loadConfig(
  env[String]("A").orElse(prop("a")).orNone,
  env[String]("B").orElse(prop("b")).orNone
) { (a, b) =>
  Config(
    a = a getOrElse "a",
    b = b getOrElse "b"
  )
}
```

and after, with `orValue`.

```scala
loadConfig(
  env[String]("A").orElse(prop("a")).orValue("a"),
  env[String]("B").orElse(prop("b")).orValue("b")
)(Config.apply)
```