### PR TITLE
Change to check all binary-compatible releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -473,19 +473,20 @@ lazy val testSettings = Seq(
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := {
-    def isReleased = !unreleasedModuleNames.value.contains(moduleName.value)
-    def isPublishing = publishArtifact.value
+    val released = !unreleasedModuleNames.value.contains(moduleName.value)
+    val publishing = publishArtifact.value
 
-    latestBinaryCompatibleVersion.value match {
-      case Some(version) if isPublishing && isReleased =>
-        Set(organization.value %% moduleName.value % version)
-      case _ =>
-        Set.empty
-    }
+    if(publishing && released)
+      binaryCompatibleVersions.value
+        .map(version => organization.value %% moduleName.value % version)
+    else
+      Set()
   },
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._
+    // format: off
     Seq()
+    // format: on
   }
 )
 

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,3 +1,7 @@
 latestVersion in ThisBuild := "0.12.0"
-latestBinaryCompatibleVersion in ThisBuild := Some("0.12.0")
+
 unreleasedModuleNames in ThisBuild := Set()
+
+binaryCompatibleVersions in ThisBuild := Set(
+  "0.12.0"
+)


### PR DESCRIPTION
When checking binary-compatibility against previous releases, check all releases which should be binary-compatible, rather than just the latest release.