### PR TITLE
Add Scala Code of Conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -16,4 +16,6 @@ support you.
 For any questions, concerns, or moderation requests please contact a
 member of the project.
 
-[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html
+- [Viktor Lövgren](mailto:github@vlovgr.se)
+
+[Scala Code of Conduct]: https://www.scala-lang.org/conduct/

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -174,7 +174,7 @@ If you're looking for a more detailed code-centric overview, you can instead tak
 There is also a small [example application](https://github.com/vlovgr/ciris-example) available to exemplify how to use the library in an application context.
 
 ### Participation
-Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](https://typelevel.org/conduct.html). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
+Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://www.scala-lang.org/conduct/). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
 
 If you would like to be involved in building Ciris, check out the [contributing guide](https://cir.is/docs/contributing).
 

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ If you're looking for a more detailed code-centric overview, you can instead tak
 There is also a small [example application](https://github.com/vlovgr/ciris-example) available to exemplify how to use the library in an application context.
 
 ### Participation
-Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://typelevel.org/conduct.html). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
+Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://www.scala-lang.org/conduct/). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
 
 If you would like to be involved in building Ciris, check out the [contributing guide](https://cir.is/docs/contributing).
 

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ If you're looking for a more detailed code-centric overview, you can instead tak
 There is also a small [example application](https://github.com/vlovgr/ciris-example) available to exemplify how to use the library in an application context.
 
 ### Participation
-Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](https://typelevel.org/conduct.html). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
+Ciris embraces pure, typeful, idiomatic functional programming in Scala, and wants to provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://typelevel.org/conduct.html). It is expected that participants follow the code of conduct in all official channels, including on GitHub and in the Gitter chat room.
 
 If you would like to be involved in building Ciris, check out the [contributing guide](https://cir.is/docs/contributing).
 


### PR DESCRIPTION
Typelevel is [switching to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and encourages all member projects to adopt it.