### PR TITLE
Adds optional description to `ConfigEntry`

### DIFF
--- a/modules/core/src/main/scala/ciris/ConfigEntry.scala
+++ b/modules/core/src/main/scala/ciris/ConfigEntry.scala
@@ -32,8 +32,26 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
   val key: K,
   val keyType: ConfigKeyType[K],
   val sourceValue: F[Either[ConfigError, S]],
-  val value: F[Either[ConfigError, V]]
+  val value: F[Either[ConfigError, V]],
+  val description: Option[String] = None
 ) extends ConfigValue[F, V] {
+
+  /**
+    * Creates a copy of this [[ConfigEntry]] that contains the
+    * description passed as parameter.
+    *
+    * @param description the description to be set
+    * @return a new [[ConfigEntry]] with the description set
+    * @example {{{
+    * scala> val entry = ConfigEntry("key", ConfigKeyType.Environment, Right("value ")).withDescription("desc")
+    * entry: ConfigEntry[api.Id, String, String, String] = ConfigEntry(key, Environment, desca)
+    *
+    * scala> entry.description
+    * res0: Option[String] = Some(desc)
+    * }}}
+    */
+  def withDescription(description: String): ConfigEntry[F, K, S, V] =
+    new ConfigEntry(key, keyType, sourceValue, value, Some(description))
 
   /**
     * Transforms the value of this [[ConfigEntry]] into type `A`, by
@@ -175,7 +193,7 @@ final class ConfigEntry[F[_]: Apply, K, S, V] private (
     new ConfigEntry(key, keyType, f(sourceValue), f(value))
 
   override def toString: String =
-    s"ConfigEntry($key, $keyType)"
+    description.fold(s"ConfigEntry($key, $keyType)")(d => s"ConfigEntry($key, $keyType, $d)")
 
   /**
     * Returns a `String` representation of this [[ConfigEntry]]

--- a/modules/core/src/test/scala/ciris/ConfigEntrySpec.scala
+++ b/modules/core/src/test/scala/ciris/ConfigEntrySpec.scala
@@ -8,7 +8,22 @@ final class ConfigEntrySpec extends PropertySpec {
       "include the key and keyType" in {
         forAll { value: String =>
           existingEntry(value).toString shouldBe
-            s"ConfigEntry(key, ConfigKeyType(test key))"
+            "ConfigEntry(key, ConfigKeyType(test key))"
+        }
+      }
+    }
+
+    "using withDescription" should {
+      "set the description" in {
+        forAll { value: String =>
+          existingEntry(value).withDescription(value).description shouldBe Some(value)
+        }
+      }
+
+      "include the description in the output of toString" in {
+        forAll { value: String =>
+          existingEntry(value).withDescription(value).toString shouldBe
+            s"ConfigEntry(key, ConfigKeyType(test key), $value)"
         }
       }
     }


### PR DESCRIPTION
The main reason to do this is to be able to use the
class `ConfigEntry` as the source of documentation
for your project.

Similar to what `--help` does for command line arguments,
you could create all the config entries and output
the expected configuration in your program (or use it
to generate readmes or so).

Changes added:
- New public attribute of type `Option[String]`
- New method `withDescription` to "set" its value

If this idea looks good to the maintainers of the repo
we could extend it a bit further by adding convenience
methods to set the description in `env`, `arg` and the likes.