### PR TITLE
Revert "Change ConfigError.decode to redact value using Secret"

### DIFF
--- a/modules/core/src/main/scala/ciris/ConfigError.scala
+++ b/modules/core/src/main/scala/ciris/ConfigError.scala
@@ -160,17 +160,21 @@ final object ConfigError {
     key: Option[ConfigKey],
     value: A
   )(implicit show: Show[A]): ConfigError = {
-    def message(valueShown: String): String =
-      key match {
-        case Some(key) =>
-          s"${key.description.capitalize} with value $valueShown cannot be converted to $typeName"
-        case None =>
-          s"Unable to convert value $valueShown to $typeName"
+    def message(valueShown: Option[String]): String =
+      (key, valueShown) match {
+        case (Some(key), Some(value)) =>
+          s"${key.description.capitalize} with value $value cannot be converted to $typeName"
+        case (Some(key), None) =>
+          s"${key.description.capitalize} cannot be converted to $typeName"
+        case (None, Some(value)) =>
+          s"Unable to convert value $value to $typeName"
+        case (None, None) =>
+          s"Unable to convert value to $typeName"
       }
 
     ConfigError.sensitive(
-      message = message(value.show),
-      redactedMessage = message(Secret(value).show)
+      message = message(Some(value.show)),
+      redactedMessage = message(None)
     )
   }
 

--- a/modules/core/src/test/scala/ciris/ConfigDecoderSpec.scala
+++ b/modules/core/src/test/scala/ciris/ConfigDecoderSpec.scala
@@ -121,9 +121,8 @@ final class ConfigDecoderSpec extends BaseSpec {
 
   test("ConfigDecoder.duration.success") {
     forAll { duration: Duration =>
-      val expected = Try(Duration(duration.toString))
-      whenever(expected.isSuccess) {
-        assert(ConfigDecoder[String, Duration].decode(None, duration.toString) == expected.toEither)
+      whenever(Try(Duration(duration.toString)).isSuccess) {
+        assert(ConfigDecoder[String, Duration].decode(None, duration.toString) == duration.asRight)
       }
     }
   }

--- a/modules/core/src/test/scala/ciris/ConfigErrorSpec.scala
+++ b/modules/core/src/test/scala/ciris/ConfigErrorSpec.scala
@@ -1,9 +1,8 @@
 package ciris
 
-import cats.data.Chain
 import cats.implicits._
 import cats.kernel.laws.discipline.EqTests
-import org.scalacheck.Gen
+import cats.data.Chain
 
 final class ConfigErrorSpec extends BaseSpec {
   test("ConfigError.and.messages") {
@@ -113,14 +112,10 @@ final class ConfigErrorSpec extends BaseSpec {
   test("ConfigError.decode.key redacted") {
     forAll { (typeName: String, key: ConfigKey, value: String) =>
       val error = ConfigError.decode(typeName, Some(key), value)
-      val valueShown = Secret(value).show
-
-      assert {
+      assert(
         error.redacted.messages === Chain
-          .one {
-            s"${key.description.capitalize} with value $valueShown cannot be converted to $typeName"
-          }
-      }
+          .one(s"${key.description.capitalize} cannot be converted to $typeName")
+      )
     }
   }
 
@@ -134,11 +129,7 @@ final class ConfigErrorSpec extends BaseSpec {
   test("ConfigError.decode.no key redacted") {
     forAll { (typeName: String, value: String) =>
       val error = ConfigError.decode(typeName, None, value)
-      val valueShown = Secret(value).show
-
-      assert {
-        error.redacted.messages === Chain.one(s"Unable to convert value $valueShown to $typeName")
-      }
+      assert(error.redacted.messages === Chain.one(s"Unable to convert value to $typeName"))
     }
   }
 
@@ -325,7 +316,7 @@ final class ConfigErrorSpec extends BaseSpec {
   }
 
   test("ConfigError#uncapitalize") {
-    forAll(Gen.alphaNumStr) { s: String =>
+    forAll { s: String =>
       val expected =
         if (s.headOption.exists(_.isUpper))
           s"${s.charAt(0).toLower}" ++ s.tail

--- a/modules/enumeratum/src/test/scala/enumeratum/CirisEnumSpec.scala
+++ b/modules/enumeratum/src/test/scala/enumeratum/CirisEnumSpec.scala
@@ -1,7 +1,6 @@
 package enumeratum
 
 import ciris._
-import cats.implicits._
 import cats.effect.{ContextShift, IO}
 import enumeratum.EnumEntry.Lowercase
 import org.scalatest.funsuite.AnyFunSuite
@@ -35,7 +34,7 @@ final class CirisEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks {
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $name to Suit",
-                s"Unable to convert value ${Secret(name).show} to Suit"
+                "Unable to convert value to Suit"
               )
             }
 

--- a/modules/enumeratum/src/test/scala/enumeratum/values/CirisValueEnumSpec.scala
+++ b/modules/enumeratum/src/test/scala/enumeratum/values/CirisValueEnumSpec.scala
@@ -40,7 +40,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $byte to CustomByteEnum",
-                s"Unable to convert value ${Secret(byte).show} to CustomByteEnum"
+                "Unable to convert value to CustomByteEnum"
               )
             }
 
@@ -61,7 +61,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $value to Byte",
-                s"Unable to convert value ${Secret(value).show} to Byte"
+                "Unable to convert value to Byte"
               )
             }
 
@@ -98,7 +98,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $char to CustomCharEnum",
-                s"Unable to convert value ${Secret(char).show} to CustomCharEnum"
+                "Unable to convert value to CustomCharEnum"
               )
             }
 
@@ -119,7 +119,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $value to Char",
-                s"Unable to convert value ${Secret(value).show} to Char"
+                "Unable to convert value to Char"
               )
             }
 
@@ -156,7 +156,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $int to CustomIntEnum",
-                s"Unable to convert value ${Secret(int).show} to CustomIntEnum"
+                "Unable to convert value to CustomIntEnum"
               )
             }
 
@@ -177,7 +177,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $value to Int",
-                s"Unable to convert value ${Secret(value).show} to Int"
+                "Unable to convert value to Int"
               )
             }
 
@@ -214,7 +214,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $long to CustomLongEnum",
-                s"Unable to convert value ${Secret(long).show} to CustomLongEnum"
+                "Unable to convert value to CustomLongEnum"
               )
             }
 
@@ -235,7 +235,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $value to Long",
-                s"Unable to convert value ${Secret(value).show} to Long"
+                "Unable to convert value to Long"
               )
             }
 
@@ -272,7 +272,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $short to CustomShortEnum",
-                s"Unable to convert value ${Secret(short).show} to CustomShortEnum"
+                "Unable to convert value to CustomShortEnum"
               )
             }
 
@@ -293,7 +293,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $value to Short",
-                s"Unable to convert value ${Secret(value).show} to Short"
+                "Unable to convert value to Short"
               )
             }
 
@@ -330,7 +330,7 @@ final class CirisValueEnumSpec extends AnyFunSuite with ScalaCheckPropertyChecks
             Left {
               ConfigError.sensitive(
                 s"Unable to convert value $string to CustomStringEnum",
-                s"Unable to convert value ${Secret(string).show} to CustomStringEnum"
+                "Unable to convert value to CustomStringEnum"
               )
             }
 

--- a/modules/refined/src/test/scala/ciris/refined/RefinedSpec.scala
+++ b/modules/refined/src/test/scala/ciris/refined/RefinedSpec.scala
@@ -27,7 +27,7 @@ final class RefinedSpec extends AnyFunSuite {
         Left {
           ConfigError.sensitive(
             "Unable to convert value 0 to eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Positive]",
-            s"Unable to convert value ${Secret(0).show} to eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Positive]"
+            "Unable to convert value to eu.timepit.refined.api.Refined[Int,eu.timepit.refined.numeric.Positive]"
           )
         }
 


### PR DESCRIPTION
Reverts vlovgr/ciris#269.

Not all values can safely be shown as partial hashes (in particular values where the key space is small).