### PR TITLE
Add an ensure function to enable validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /website/variables.js
 /website/yarn.lock
 target/
+.bloop/
+.metals/
+project/metals.sbt

--- a/modules/core/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/src/test/scala/ciris/ConfigValueSpec.scala
@@ -857,4 +857,50 @@ final class ConfigValueSpec extends BaseSpec {
   test("ConfigValue.secret.missing") {
     check(missing.secret, missing.asInstanceOf[ConfigValue[Secret[String]]])
   }
+
+  val validationSuccess: String => Boolean = _ => true
+  val validationFailed: String => Boolean = _ => false
+
+  test("ConfigValue.loaded.ensure success") {
+    check(
+      loaded.ensure(validationSuccess),
+      loaded
+    )
+  }
+
+  test("ConfigValue.loaded.ensure failed") {
+    checkError(loaded.ensure(validationFailed), ConfigError("Validation function returned false"))
+  }
+
+  test("ConfigValue.loaded.ensure failed with message") {
+    checkError(loaded.ensure(validationFailed, "failed"), ConfigError("failed"))
+  }
+
+  test("ConfigValue.failed.ensure success") {
+    checkError(
+      failed.ensure(validationSuccess),
+      failedError
+    )
+  }
+
+  test("ConfigValue.failed.ensure failed") {
+    checkError(
+      failed.ensure(validationFailed),
+      failedError
+    )
+  }
+
+  test("ConfigValue.default.ensure success") {
+    check(
+      default.ensure(validationSuccess),
+      default
+    )
+  }
+
+  test("ConfigValue.default.ensure failed") {
+    checkError(
+      failed.ensure(validationFailed),
+      failedError
+    )
+  }
 }


### PR DESCRIPTION
Similar to scala.Predef.Ensuring, the goal of this
function is to ease with validation of a ConfigValue.

I found myself doing:

```scala
val calendarId: ConfigValue[String] = {
  val original = env("LMAH_CALENDAR_ID")
  original flatMap { cId =>
    if (cId.contains("@")) {
      original
    } else {
      ConfigValue.failed(ConfigError("Expected an email as the CALENDAR ID"))
    }
  }
}
```

Now I could replace it with:

```scala
val calendarId: ConfigValue[String] =
  env("LMAH_CALENDAR_ID").ensure(_.contains("@"), "Expected an email as
the CALENDAR ID")
```
