### PR TITLE
Remove bad trailing comma in test

### DIFF
--- a/modules/core/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/src/test/scala/ciris/ConfigValueSpec.scala
@@ -288,7 +288,7 @@ final class ConfigValueSpec extends BaseSpec {
 
   test("ConfigValue.eval.error") {
     checkLoadFail {
-      ConfigValue.eval(IO.raiseError[ConfigValue[String]](ConfigError("").throwable)),
+      ConfigValue.eval(IO.raiseError[ConfigValue[String]](ConfigError("").throwable))
     }
   }
 


### PR DESCRIPTION
Noticed in community build

https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3305/

The syntax was previously too loose.