### PR TITLE
Add Applicative instance for ConfigValue

### DIFF
--- a/modules/core/src/main/scala/ciris/ConfigValue.scala
+++ b/modules/core/src/main/scala/ciris/ConfigValue.scala
@@ -6,7 +6,7 @@
 
 package ciris
 
-import cats.{Apply, FlatMap, NonEmptyParallel, Show}
+import cats.{Applicative, Apply, FlatMap, NonEmptyParallel, Show}
 import cats.arrow.FunctionK
 import cats.effect.{Async, Blocker, ContextShift, Effect}
 import cats.implicits._
@@ -500,6 +500,17 @@ final object ConfigValue {
 
       override final def map[A, B](pa: Par[A])(f: A => B): Par[B] =
         Par(pa.unwrap.map(f))
+    }
+
+  /**
+    * @group Instances
+    */
+  implicit final val configValueApplicative: Applicative[ConfigValue] =
+    new Applicative[ConfigValue] {
+      override def pure[A](x: A): ConfigValue[A] = ConfigValue.default(x)
+
+      override def ap[A, B](ff: ConfigValue[A => B])(fa: ConfigValue[A]): ConfigValue[B] =
+        ff.flatMap(ff_ => fa.map(ff_))
     }
 
   /**


### PR DESCRIPTION
In our codebase we required the ability to `sequence` a `List[ConfigValue[...]]` into a `ConfigValue[List[...]]`. Adding an `Applicative` instance for `ConfigValue` allows us to do that:

```scala
Blocker[F].flatMap(params[F]).map { param =>
  List(...).map(param(_).as[Credentials]).sequence
}
```

I'm happy to carry it in our codebase, but I thought it might be useful for others too :)