### PR TITLE
Add ConfigDecoder#redacted

### DIFF
--- a/modules/core/src/main/scala/ciris/ConfigDecoder.scala
+++ b/modules/core/src/main/scala/ciris/ConfigDecoder.scala
@@ -82,6 +82,13 @@ sealed abstract class ConfigDecoder[A, B] {
     implicit show: Show[B]
   ): ConfigDecoder[A, C] =
     mapEither { (key, b) => f(b).toRight(ConfigError.decode(typeName, key, b)) }
+
+  /**
+    * Returns a new [[ConfigDecoder]] which redacts
+    * sensitive details from error messages.
+    */
+  final def redacted: ConfigDecoder[A, B] =
+    ConfigDecoder.instance { (key, value) => decode(key, value).leftMap(_.redacted) }
 }
 
 /**


### PR DESCRIPTION
Particularly useful when defining decoders for sensitive types, where the value should never be in error messages.