### PR TITLE
Add Host and Port ConfigDecoders in the Http4s module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,3 @@
 /website/variables.js
 /website/yarn.lock
 target/
-.vscode
-.bloop
-.bsp
-.metals
-project/project
-project/metals.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /website/variables.js
 /website/yarn.lock
 target/
+.vscode
+.bloop
+.bsp
+.metals
+project/project
+project/metals.sbt

--- a/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
+++ b/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
@@ -6,17 +6,17 @@
 
 package ciris
 
-import org.http4s.Uri
 import com.comcast.ip4s.Host
 import com.comcast.ip4s.Port
+import org.http4s.Uri
 
 package object http4s {
-  implicit final val uriConfigDecoder: ConfigDecoder[String, Uri] =
-    ConfigDecoder[String].mapOption("Uri")(Uri.fromString(_).toOption)
-
   implicit final val hostConfigDecoder: ConfigDecoder[String, Host] =
     ConfigDecoder[String].mapOption("Host")(Host.fromString)
 
   implicit final val portConfigDecoder: ConfigDecoder[String, Port] =
     ConfigDecoder[String].mapOption("Host")(Port.fromString)
+
+  implicit final val uriConfigDecoder: ConfigDecoder[String, Uri] =
+    ConfigDecoder[String].mapOption("Uri")(Uri.fromString(_).toOption)
 }

--- a/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
+++ b/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
@@ -7,8 +7,16 @@
 package ciris
 
 import org.http4s.Uri
+import com.comcast.ip4s.Host
+import com.comcast.ip4s.Port
 
 package object http4s {
   implicit final val uriConfigDecoder: ConfigDecoder[String, Uri] =
     ConfigDecoder[String].mapOption("Uri")(Uri.fromString(_).toOption)
+
+  implicit final val hostConfigDecoder: ConfigDecoder[String, Host] =
+    ConfigDecoder[String].mapOption("Host")(Host.fromString)
+
+  implicit final val portConfigDecoder: ConfigDecoder[String, Port] =
+    ConfigDecoder[String].mapOption("Host")(Port.fromString)
 }

--- a/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
+++ b/modules/http4s/src/main/scala/ciris/http4s/http4s.scala
@@ -15,7 +15,7 @@ package object http4s {
     ConfigDecoder[String].mapOption("Host")(Host.fromString)
 
   implicit final val portConfigDecoder: ConfigDecoder[String, Port] =
-    ConfigDecoder[String].mapOption("Host")(Port.fromString)
+    ConfigDecoder[String].mapOption("Port")(Port.fromString)
 
   implicit final val uriConfigDecoder: ConfigDecoder[String, Uri] =
     ConfigDecoder[String].mapOption("Uri")(Uri.fromString(_).toOption)

--- a/modules/http4s/src/test/scala/ciris/http4s/Http4sSpec.scala
+++ b/modules/http4s/src/test/scala/ciris/http4s/Http4sSpec.scala
@@ -9,24 +9,14 @@ package ciris.http4s
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import ciris._
+import com.comcast.ip4s._
 import org.http4s.syntax.literals._
 import org.http4s.Uri
 import org.scalatest.funsuite.AnyFunSuite
-import com.comcast.ip4s._
 
 final class Http4sSpec extends AnyFunSuite {
-  test("uriConfigDecoder.success") {
-    assert {
-      val actual = default("https://github.com/vlovgr/ciris").as[Uri].attempt[IO].unsafeRunSync()
-      val expected = Right(uri"https://github.com/vlovgr/ciris")
-      actual == expected
-    }
-  }
-
-  test("uriConfigDecoder.error") {
-    assert {
-      default("invalid uri").as[Uri].attempt[IO].unsafeRunSync().isLeft
-    }
+  test("hostConfigDecoder.error") {
+    default("🍋.🍊.🍉.🍐").as[Host].attempt[IO].unsafeRunSync().isLeft
   }
 
   test("hostConfigDecoder.success") {
@@ -47,28 +37,33 @@ final class Http4sSpec extends AnyFunSuite {
       val expected = Right(ip"::1")
       actual === expected
     }
-
   }
 
-  test("hostConfigDecoder.error") {
-    default("🍋.🍊.🍉.🍐").as[Host].attempt[IO].unsafeRunSync().isLeft
+  test("portConfigDecoder.error") {
+    assert {
+      default("🚨").as[Port].attempt[IO].unsafeRunSync().isLeft
+    }
   }
 
   test("portConfigDecoder.success") {
-
     assert {
       val actual = default("12345").as[Port].attempt[IO].unsafeRunSync()
       val expected = Right(port"12345")
       actual === expected
     }
-
   }
 
-  test("portConfigDecoder.error") {
-
+  test("uriConfigDecoder.error") {
     assert {
-      default("🚨").as[Port].attempt[IO].unsafeRunSync().isLeft
+      default("invalid uri").as[Uri].attempt[IO].unsafeRunSync().isLeft
     }
+  }
 
+  test("uriConfigDecoder.success") {
+    assert {
+      val actual = default("https://github.com/vlovgr/ciris").as[Uri].attempt[IO].unsafeRunSync()
+      val expected = Right(uri"https://github.com/vlovgr/ciris")
+      actual == expected
+    }
   }
 }

--- a/modules/http4s/src/test/scala/ciris/http4s/Http4sSpec.scala
+++ b/modules/http4s/src/test/scala/ciris/http4s/Http4sSpec.scala
@@ -12,6 +12,7 @@ import ciris._
 import org.http4s.syntax.literals._
 import org.http4s.Uri
 import org.scalatest.funsuite.AnyFunSuite
+import com.comcast.ip4s._
 
 final class Http4sSpec extends AnyFunSuite {
   test("uriConfigDecoder.success") {
@@ -26,5 +27,48 @@ final class Http4sSpec extends AnyFunSuite {
     assert {
       default("invalid uri").as[Uri].attempt[IO].unsafeRunSync().isLeft
     }
+  }
+
+  test("hostConfigDecoder.success") {
+    assert {
+      val actual = default("localhost").as[Host].attempt[IO].unsafeRunSync()
+      val expected = Right(host"localhost")
+      actual === expected
+    }
+
+    assert {
+      val actual = default("0.0.0.0").as[Host].attempt[IO].unsafeRunSync()
+      val expected = Right(ip"0.0.0.0")
+      actual === expected
+    }
+
+    assert {
+      val actual = default("::1").as[Host].attempt[IO].unsafeRunSync()
+      val expected = Right(ip"::1")
+      actual === expected
+    }
+
+  }
+
+  test("hostConfigDecoder.error") {
+    default("🍋.🍊.🍉.🍐").as[Host].attempt[IO].unsafeRunSync().isLeft
+  }
+
+  test("portConfigDecoder.success") {
+
+    assert {
+      val actual = default("12345").as[Port].attempt[IO].unsafeRunSync()
+      val expected = Right(port"12345")
+      actual === expected
+    }
+
+  }
+
+  test("portConfigDecoder.error") {
+
+    assert {
+      default("🚨").as[Port].attempt[IO].unsafeRunSync().isLeft
+    }
+
   }
 }


### PR DESCRIPTION
Added the support for ip4s Host and Port as config values (+ tests) IP4s is a transitive depndency of Http4s, and those types are required to setup server backends.

I also added some lines to the `.gitignore` to help vscode users contributing.