### PR TITLE
Update cats-effect to 3.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import scala.scalanative.build.Mode
 
-val catsEffectVersion = "3.4.10"
+val catsEffectVersion = "3.5.0"
 
 val circeVersion = "0.14.5"
 
@@ -8,7 +8,7 @@ val circeYamlVersion = "0.14.2"
 
 val enumeratumVersion = "1.7.2"
 
-val http4sVersion = "0.23.18"
+val http4sVersion = "0.23.19"
 
 val refinedVersion = "0.10.3"
 

--- a/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -137,34 +137,68 @@ final class ConfigValueSpec extends CatsEffectSuite with ScalaCheckEffectSuite w
 
   test("ConfigValue.async.default") {
     check(
-      ConfigValue.async[IO, String] { cb => cb(Right(default)) },
+      ConfigValue.async[IO, String] { cb => IO(cb(Right(default))).as(None) },
       default
     )
   }
 
   test("ConfigValue.async.error") {
     checkLoadFail {
-      ConfigValue.async[IO, String] { cb => cb(Left(new RuntimeException)) }
+      ConfigValue.async[IO, String] { cb => IO(cb(Left(new RuntimeException))).as(None) }
     }
   }
 
   test("ConfigValue.async.failed") {
     check(
-      ConfigValue.async[IO, String] { cb => cb(Right(failed)) },
+      ConfigValue.async[IO, String] { cb => IO(cb(Right(failed))).as(None) },
       failed
     )
   }
 
   test("ConfigValue.async.loaded") {
     check(
-      ConfigValue.async[IO, String] { cb => cb(Right(loaded)) },
+      ConfigValue.async[IO, String] { cb => IO(cb(Right(loaded))).as(None) },
       loaded
     )
   }
 
   test("ConfigValue.async.missing") {
     check(
-      ConfigValue.async[IO, String] { cb => cb(Right(missing)) },
+      ConfigValue.async[IO, String] { cb => IO(cb(Right(missing))).as(None) },
+      missing
+    )
+  }
+
+  test("ConfigValue.async_.default") {
+    check(
+      ConfigValue.async_[IO, String] { cb => cb(Right(default)) },
+      default
+    )
+  }
+
+  test("ConfigValue.async_.error") {
+    checkLoadFail {
+      ConfigValue.async_[IO, String] { cb => cb(Left(new RuntimeException)) }
+    }
+  }
+
+  test("ConfigValue.async_.failed") {
+    check(
+      ConfigValue.async_[IO, String] { cb => cb(Right(failed)) },
+      failed
+    )
+  }
+
+  test("ConfigValue.async_.loaded") {
+    check(
+      ConfigValue.async_[IO, String] { cb => cb(Right(loaded)) },
+      loaded
+    )
+  }
+
+  test("ConfigValue.async_.missing") {
+    check(
+      ConfigValue.async_[IO, String] { cb => cb(Right(missing)) },
       missing
     )
   }


### PR DESCRIPTION
Separates `ConfigValue.async` into `async` and `async_` to mimic cats-effect.

Also updates http4s to 0.23.19.