### PR TITLE
Change ConfigException to indent messages after line breaks

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigException.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigException.scala
@@ -36,12 +36,18 @@ object ConfigException {
   private[ciris] final val entryLeading: String =
     "\n  - "
 
+  private[ciris] final val entryNewLineLeading: String =
+    " " * (entryLeading.length - 1)
+
   private[ciris] final val entryTrailing: String =
     "."
 
+  private[ciris] final def formatMessage(message: String): String =
+    message.replaceAll("\n", s"\n$entryNewLineLeading")
+
   private[ciris] final def message(error: ConfigError): String = {
     val messages =
-      error.messages
+      error.messages.map(formatMessage)
 
     val builder =
       new java.lang.StringBuilder(messageLength(messages))

--- a/modules/core/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/ConfigExceptionSpec.scala
@@ -25,7 +25,7 @@ final class ConfigExceptionSpec extends DisciplineSuite with Generators {
         exception.getMessage
 
       val messages =
-        exception.error.messages
+        exception.error.messages.map(ConfigException.formatMessage)
 
       val withEntryTrailing =
         messages
@@ -63,7 +63,8 @@ final class ConfigExceptionSpec extends DisciplineSuite with Generators {
 
   property("ConfigException.messageLength") {
     forAll { (exception: ConfigException) =>
-      val expected = ConfigException.messageLength(exception.error.messages)
+      val messages = exception.error.messages.map(ConfigException.formatMessage)
+      val expected = ConfigException.messageLength(messages)
       val actual = exception.getMessage.length
       actual === expected
     }

--- a/modules/core/shared/src/test/scala/ciris/Generators.scala
+++ b/modules/core/shared/src/test/scala/ciris/Generators.scala
@@ -40,7 +40,8 @@ trait Generators extends GeneratorsRuntimePlatform {
   val configErrorMessageGen: Gen[String] =
     Gen.oneOf(
       Gen.alphaNumStr,
-      Gen.alphaNumStr.map(_ ++ ConfigException.entryTrailing)
+      Gen.alphaNumStr.map(_ ++ ConfigException.entryTrailing),
+      Gen.alphaNumStr.map(s => s"$s\n$s")
     )
 
   val configErrorGen: Gen[ConfigError] =


### PR DESCRIPTION
Messages in `ConfigException` are now indented after line breaks.

Example before:
```
ciris.ConfigException: configuration loading failed with the following errors.
  - Failed to parse file at <path> with charset UTF-8:
// TODO
^
expectation:
* must end the string.
```

Example after:
```
ciris.ConfigException: configuration loading failed with the following errors.
  - Failed to parse file at <path> with charset UTF-8:
    // TODO
    ^
    expectation:
    * must end the string.
```