### PR TITLE
WIP feat: Add introspectable ConfigSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /website/variables.js
 /website/yarn.lock
 target/
+/.metals/
+.bloop/
+/.bsp/
+/.vscode/
+metals.sbt

--- a/modules/core/shared/src/main/scala/ciris/ConfigCodec.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigCodec.scala
@@ -37,9 +37,9 @@ sealed abstract class ConfigCodec[A, B] {
     )
 
   /**
-  * Returns a new [[ConfigCodec]] which applies the
-  * specified function on the value before decoding.
-  */
+    * Returns a new [[ConfigCodec]] which applies the
+    * specified function on the value before decoding.
+    */
   final def icontramap[C](f: C => A)(g: A => C): ConfigCodec[C, B] =
     ConfigCodec.instance(
       (key, value) => decode(key, f(value)),
@@ -76,7 +76,9 @@ sealed abstract class ConfigCodec[A, B] {
     * Returns a new [[ConfigCodec]] which successfully decodes
     * values for which the specified function returns `Right`.
     */
-  final def imapEither[C](f: (Option[ConfigKey], B) => Either[ConfigError, C])(g: C => B): ConfigCodec[A, C] =
+  final def imapEither[C](
+    f: (Option[ConfigKey], B) => Either[ConfigError, C]
+  )(g: C => B): ConfigCodec[A, C] =
     ConfigCodec.instance(
       (key, value) => decode(key, value).flatMap(f(key, _)),
       g andThen encode
@@ -270,8 +272,8 @@ object ConfigCodec {
   /**
     * @group Codecs
     */
-  implicit final def secretConfigCodec[A, B](implicit
-    codec: ConfigCodec[A, B],
+  implicit final def secretConfigCodec[A, B](
+    implicit codec: ConfigCodec[A, B],
     show: Show[A]
   ): ConfigCodec[Secret[A], B] =
     codec.icontramap[Secret[A]](_.value)(Secret.apply)
@@ -358,8 +360,8 @@ object ConfigCodec {
     */
   implicit final def ConfigCodecInvariant[C]: Invariant[ConfigCodec[C, *]] =
     new Invariant[ConfigCodec[C, *]] {
-      
-      override def imap[A, B](fa: ConfigCodec[C,A])(f: A => B)(g: B => A): ConfigCodec[C,B] =
+
+      override def imap[A, B](fa: ConfigCodec[C, A])(f: A => B)(g: B => A): ConfigCodec[C, B] =
         fa.imap(f)(g)
     }
 }

--- a/modules/core/shared/src/main/scala/ciris/ConfigCodec.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigCodec.scala
@@ -1,0 +1,365 @@
+package ciris
+
+import cats.Show
+import cats.syntax.all._
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import cats.Invariant
+
+/**
+  * Decodes/Encodes configuration values from a first type to a second type.
+  */
+sealed abstract class ConfigCodec[A, B] {
+
+  /**
+    * Returns a new [[ConfigCodec]] which attempts to decode
+    * values to the specified type.
+    */
+  final def as[C](implicit codec: ConfigCodec[B, C]): ConfigCodec[A, C] =
+    imapEither(codec.decode)(codec.encode)
+
+  /**
+    * Returns a new [[ConfigCodec]] which successfully decodes
+    * values for which the specified partial function is defined.
+    */
+  final def collect[C](typeName: String)(f: PartialFunction[B, C])(g: C => B)(
+    implicit show: Show[B]
+  ): ConfigCodec[A, C] =
+    ConfigCodec.instance(
+      (key, value) =>
+        decode(key, value).flatMap { b =>
+          f.andThen(_.asRight)
+            .applyOrElse(
+              b,
+              (b: B) => Left(ConfigError.decode(typeName, key, b))
+            )
+        },
+      g andThen encode
+    )
+
+  /**
+  * Returns a new [[ConfigCodec]] which applies the
+  * specified function on the value before decoding.
+  */
+  final def icontramap[C](f: C => A)(g: A => C): ConfigCodec[C, B] =
+    ConfigCodec.instance(
+      (key, value) => decode(key, f(value)),
+      g compose encode
+    )
+
+  /**
+    * Attempts to decode the specified value to the second type.
+    *
+    * The key may be used for improved error messages. The key
+    * is present for a single configuration value, and missing
+    * for default values and composed values.
+    *
+    * @see [[ConfigError.decode]] for creating decode errors
+    */
+  def decode(key: Option[ConfigKey], value: A): Either[ConfigError, B]
+
+  /**
+    * Encode the specified value to the first type.
+    */
+  def encode(value: B): A
+
+  /**
+    * Returns a new [[ConfigCodec]] which applies the
+    * specified function on successfully decoded values.
+    */
+  final def imap[C](f: B => C)(g: C => B): ConfigCodec[A, C] =
+    ConfigCodec.instance(
+      (key, value) => decode(key, value).map(f),
+      g andThen encode
+    )
+
+  /**
+    * Returns a new [[ConfigCodec]] which successfully decodes
+    * values for which the specified function returns `Right`.
+    */
+  final def imapEither[C](f: (Option[ConfigKey], B) => Either[ConfigError, C])(g: C => B): ConfigCodec[A, C] =
+    ConfigCodec.instance(
+      (key, value) => decode(key, value).flatMap(f(key, _)),
+      g andThen encode
+    )
+
+  /**
+    * Returns a new [[ConfigCodec]] which successfully decodes
+    * values for which the specified function returns `Some`.
+    */
+  final def imapOption[C](typeName: String)(f: B => Option[C])(g: C => B)(
+    implicit show: Show[B]
+  ): ConfigCodec[A, C] =
+    imapEither((key, b) => f(b).toRight(ConfigError.decode(typeName, key, b)))(g)
+
+  /**
+    * Returns a new [[ConfigCodec]] which redacts
+    * sensitive details from error messages.
+    */
+  final def redacted: ConfigCodec[A, B] =
+    ConfigCodec.instance((key, value) => decode(key, value).leftMap(_.redacted), encode)
+}
+
+/**
+  * @groupname Create Creating Instances
+  * @groupprio Create 0
+  *
+  * @groupname Codecs Codec Instances
+  * @groupprio Codecs 1
+  *
+  * @groupname Instances Type Class Instances
+  * @groupprio Instances 2
+  */
+object ConfigCodec {
+
+  /**
+    * Returns a new [[ConfigCodec]] for the specified type
+    * without performing any kind of decoding.
+    *
+    * @group Create
+    */
+  final def identity[A]: ConfigCodec[A, A] =
+    identityConfigCodec
+
+  /**
+    * Returns a new [[ConfigCodec]] for the specified type
+    * without performing any kind of decoding. Alias for the
+    * [[ConfigCodec.identity]] function.
+    *
+    * @group Create
+    */
+  final def apply[A]: ConfigCodec[A, A] =
+    identity
+
+  /**
+    * Returns a [[ConfigCodec]] instance between the two
+    * specified types if an instance is available.
+    *
+    * @group Create
+    */
+  final def apply[A, B](implicit codec: ConfigCodec[A, B]): ConfigCodec[A, B] =
+    codec
+
+  def fromStringOption[A](typeName: String)(f: String => Option[A]): ConfigCodec[String, A] =
+    ConfigCodec[String].imapOption(typeName)(f)(_.toString())
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringBigDecimalConfigCodec: ConfigCodec[String, BigDecimal] =
+    fromStringOption("BigDecimal") { s =>
+      try {
+        Some(BigDecimal(s))
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringBigIntConfigCodec: ConfigCodec[String, BigInt] =
+    fromStringOption("BigInt") { s =>
+      try {
+        Some(BigInt(s))
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringBooleanConfigCodec: ConfigCodec[String, Boolean] =
+    fromStringOption("Boolean") { s =>
+      if (s.equalsIgnoreCase("true") || s.equalsIgnoreCase("yes") || s.equalsIgnoreCase("on"))
+        Some(true)
+      else if (s.equalsIgnoreCase("false") || s.equalsIgnoreCase("no") || s.equalsIgnoreCase("off"))
+        Some(false)
+      else
+        None
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringByteConfigCodec: ConfigCodec[String, Byte] =
+    fromStringOption("Byte") { s =>
+      try {
+        Some(s.toByte)
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringCharConfigCodec: ConfigCodec[String, Char] =
+    ConfigCodec[String].collect("Char") {
+      case s if s.length == 1 => s.charAt(0)
+    }(_.toString())
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringDoubleConfigCodec: ConfigCodec[String, Double] =
+    fromStringOption("Double") { s =>
+      try {
+        Some {
+          if (s.lastOption.exists(_ == '%')) {
+            s.init.toDouble / 100d
+          } else {
+            s.toDouble
+          }
+        }
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringDurationConfigCodec: ConfigCodec[String, Duration] =
+    fromStringOption("Duration") { s =>
+      try {
+        Some(Duration(s))
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringFiniteDurationConfigCodec: ConfigCodec[String, FiniteDuration] =
+    ConfigCodec[String, Duration].collect("FiniteDuration") { case finite: FiniteDuration =>
+      finite
+    }(x => x)
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringFloatConfigCodec: ConfigCodec[String, Float] =
+    fromStringOption("Float") { s =>
+      try {
+        Some {
+          if (s.lastOption.exists(_ == '%')) {
+            s.init.toFloat / 100f
+          } else {
+            s.toFloat
+          }
+        }
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final def identityConfigCodec[A]: ConfigCodec[A, A] =
+    ConfigCodec.lift[A, A](_.asRight)(x => x)
+
+  /**
+    * @group Codecs
+    */
+  implicit final def secretConfigCodec[A, B](implicit
+    codec: ConfigCodec[A, B],
+    show: Show[A]
+  ): ConfigCodec[Secret[A], B] =
+    codec.icontramap[Secret[A]](_.value)(Secret.apply)
+
+  /**
+    * Returns a new [[ConfigCodec]] which decodes values
+    * using the specified function, with access to the key.
+    *
+    * If the decode function does not need access to the key,
+    * then we can use [[ConfigCodec.lift]] instead.
+    *
+    * @group Create
+    */
+  final def instance[A, B](
+    decode: (Option[ConfigKey], A) => Either[ConfigError, B],
+    encode: B => A
+  ): ConfigCodec[A, B] = {
+    val _decode = decode
+    val _encode = encode
+    new ConfigCodec[A, B] {
+      override final def decode(key: Option[ConfigKey], value: A): Either[ConfigError, B] =
+        _decode(key, value)
+
+      override def encode(value: B): A = _encode(value)
+
+      override final def toString: String =
+        "ConfigCodec$" + System.identityHashCode(this)
+    }
+  }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringIntConfigCodec: ConfigCodec[String, Int] =
+    fromStringOption("Int") { s =>
+      try {
+        Some(s.toInt)
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * Returns a new [[ConfigCodec]] which decodes values
+    * using the specified function.
+    *
+    * If the decode function needs access to the key, then
+    * we can use [[ConfigCodec.instance]] instead.
+    *
+    * @group Create
+    */
+  final def lift[A, B](decode: A => Either[ConfigError, B])(encode: B => A): ConfigCodec[A, B] =
+    ConfigCodec.instance((_, value) => decode(value), encode)
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringLongConfigCodec: ConfigCodec[String, Long] =
+    fromStringOption("Long") { s =>
+      try {
+        Some(s.toLong)
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Codecs
+    */
+  implicit final val stringShortConfigCodec: ConfigCodec[String, Short] =
+    fromStringOption("Short") { s =>
+      try {
+        Some(s.toShort)
+      } catch {
+        case _: NumberFormatException =>
+          None
+      }
+    }
+
+  /**
+    * @group Instances
+    */
+  implicit final def ConfigCodecInvariant[C]: Invariant[ConfigCodec[C, *]] =
+    new Invariant[ConfigCodec[C, *]] {
+      
+      override def imap[A, B](fa: ConfigCodec[C,A])(f: A => B)(g: B => A): ConfigCodec[C,B] =
+        fa.imap(f)(g)
+    }
+}

--- a/modules/core/shared/src/main/scala/ciris/ConfigField.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigField.scala
@@ -1,0 +1,9 @@
+package ciris
+
+/**
+  * A single configuration field.
+  *
+  * @param key the field/entry key
+  * @param defaultValue the value to use if this field is absent
+  */
+final case class ConfigField(key: ConfigKey, defaultValue: Option[String])

--- a/modules/core/shared/src/main/scala/ciris/ConfigSpec.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigSpec.scala
@@ -1,0 +1,127 @@
+package ciris
+
+import cats.InvariantSemigroupal
+import cats.Show
+import cats.syntax.semigroupal._
+import ciris.{Secret => SecretValue}
+import ciris.{UseOnceSecret => UseOnceSecretValue}
+import cats.data.NonEmptyList
+import cats.effect.kernel.Async
+
+/**
+  * High-level config representation. Can be used for introspection, doc derivation...
+  */
+sealed trait ConfigSpec[A] {
+
+  import ConfigSpec._
+
+  def secret(implicit show: Show[A]): ConfigSpec[SecretValue[A]] = Secret(this, show)
+
+  def useOnceSecret(implicit ev: A <:< Array[Char]): ConfigSpec[UseOnceSecretValue] = UseOnceSecret(this, ev)
+
+  def default(value: A): ConfigSpec[A] = Default(this, value)
+
+  def or(right: ConfigSpec[A]): ConfigSpec[A] = {
+    def getAlternatives(spec: ConfigSpec[A]) = spec match {
+      case Alternatives(alternatives) => alternatives
+      case _                          => NonEmptyList.one(spec)
+    }
+
+    Alternatives(getAlternatives(this) ::: getAlternatives(right))
+  }
+
+  def as[B](implicit codec: ConfigCodec[A, B]): ConfigSpec[B] = Codec(this, codec)
+
+  /**
+    * Move default values to the leaves of this spec.
+    *   
+    * @return a new [[ConfigSpec]] equivalent to this one but with default values at its leaves
+    */
+  lazy val loweredDefaults: ConfigSpec[A] = loweredDefaultsRec(None)
+
+  protected def loweredDefaultsRec(defaultValue: Option[A]): ConfigSpec[A]
+
+  def toConfigValue[F[_]]: ConfigValue[F, A]
+
+  def load[F[x]](implicit F: Async[F]): F[A] = toConfigValue[F].load
+}
+
+object ConfigSpec {
+  sealed trait Leaf[A] extends ConfigSpec[A] {
+    override protected def loweredDefaultsRec(defaultValue: Option[A]): ConfigSpec[A] =
+      defaultValue.fold[ConfigSpec[A]](this)(Default(this, _))
+  }
+
+  case class Pure[A](value: A) extends Leaf[A] {
+    override def toConfigValue[F[_]]: ConfigValue[F,A] = ConfigValue.loaded(ConfigKey("pure value"), value)
+  }
+  case class Environment(key: String) extends Leaf[String] {
+    override def toConfigValue[F[_]]: ConfigValue[F, String] = ciris.env(key)
+  }
+  case class Property(key: String) extends Leaf[String] {
+    override def toConfigValue[F[_]]: ConfigValue[F, String] = ciris.prop(key)
+  }
+  case class Secret[A](spec: ConfigSpec[A], show: Show[A]) extends ConfigSpec[SecretValue[A]] {
+    override def toConfigValue[F[_]]: ConfigValue[F,SecretValue[A]] = spec.toConfigValue[F].secret(show)
+
+    override protected def loweredDefaultsRec(defaultValue: Option[SecretValue[A]]): ConfigSpec[SecretValue[A]] =
+      Secret(spec.loweredDefaultsRec(defaultValue.map(_.value)), show)
+  }
+  case class UseOnceSecret[A](spec: ConfigSpec[A], ev: A <:< Array[Char]) extends ConfigSpec[UseOnceSecretValue] {
+    override def toConfigValue[F[_]]: ConfigValue[F,UseOnceSecretValue] = spec.toConfigValue[F].useOnceSecret(ev)
+
+    override protected def loweredDefaultsRec(defaultValue: Option[UseOnceSecretValue]): ConfigSpec[UseOnceSecretValue] =
+      defaultValue.fold[ConfigSpec[UseOnceSecretValue]](this)(Default(this, _))
+  }
+  case class Default[A](spec: ConfigSpec[A], defaultValue: A) extends ConfigSpec[A] {
+    override def toConfigValue[F[_]]: ConfigValue[F,A] = spec.toConfigValue[F].default(defaultValue)
+
+    override protected def loweredDefaultsRec(defaultValueParam: Option[A]): ConfigSpec[A] =
+      spec.loweredDefaultsRec(defaultValueParam.orElse(Some(defaultValue)))
+  }
+  case class Alternatives[A](alternatives: NonEmptyList[ConfigSpec[A]]) extends ConfigSpec[A] {
+    override def toConfigValue[F[_]]: ConfigValue[F,A] = alternatives.map(_.toConfigValue[F]).reduceLeft(_ or _)
+
+    override protected def loweredDefaultsRec(defaultValue: Option[A]): ConfigSpec[A] =
+      Alternatives(alternatives.map(_.loweredDefaultsRec(defaultValue)))
+  }
+  case class IsoMap[A, B](spec: ConfigSpec[A], f: A => B, g: B => A) extends ConfigSpec[B] {
+    override def toConfigValue[F[_]]: ConfigValue[F,B] = spec.toConfigValue[F].map(f)
+
+    override protected def loweredDefaultsRec(defaultValue: Option[B]): ConfigSpec[B] =
+      IsoMap(spec.loweredDefaultsRec(defaultValue.map(g)), f, g)
+  }
+
+  case class Codec[A, B](spec: ConfigSpec[A], codec: ConfigCodec[A, B]) extends ConfigSpec[B] {
+    private lazy val decoder = ConfigDecoder.instance(codec.decode)
+
+    override def as[C](implicit codecC: ConfigCodec[B,C]): ConfigSpec[C] =
+      Codec(spec, codec.imapEither(codecC.decode)(codecC.encode)) 
+
+    override def toConfigValue[F[_]]: ConfigValue[F,B] = spec.toConfigValue[F].as(decoder)
+
+    override protected def loweredDefaultsRec(defaultValue: Option[B]): ConfigSpec[B] =
+      Codec(spec.loweredDefaultsRec(defaultValue.map(codec.encode)), codec)
+  }
+
+  case class Product[A, B](specA: ConfigSpec[A], specB: ConfigSpec[B]) extends ConfigSpec[(A, B)] {
+    override def toConfigValue[F[_]]: ConfigValue[F,(A, B)] = specA.toConfigValue[F].product(specB.toConfigValue[F])
+
+    override protected def loweredDefaultsRec(defaultValue: Option[(A, B)]): ConfigSpec[(A, B)] =
+      defaultValue.fold(this)(v => Product(specA.default(v._1), specB.default(v._2)))
+  }
+
+  def env(key: String): ConfigSpec[String] = Environment(key)
+  def prop(key: String): ConfigSpec[String] = Property(key)
+  def oneOf[A](alternatives: NonEmptyList[ConfigSpec[A]]): ConfigSpec[A] = Alternatives(alternatives)
+
+  implicit val invariantSemigroupalForSpec: InvariantSemigroupal[ConfigSpec] = new InvariantSemigroupal[ConfigSpec] {
+
+    override def imap[A, B](fa: ConfigSpec[A])(f: A => B)(g: B => A): ConfigSpec[B] = fa match {
+      case IsoMap(spec, f0, g0) => IsoMap(spec, f0 andThen f, g0 compose g)
+      case _ => IsoMap(fa, f, g)
+    }
+
+    override def product[A, B](fa: ConfigSpec[A], fb: ConfigSpec[B]): ConfigSpec[(A, B)] = Product(fa, fb)
+  }
+}


### PR DESCRIPTION
Add `ConfigSpec`, an higher-level equivalent of `ConfigValue` that can be compiled to `ConfigValue` and introspected. This is useful for deriving documentation or default configuration files/maps (e.g [for Kubernetes](https://kubernetes.io/docs/concepts/configuration/configmap/)). Example of MD documentation derivation:

```scala
import cats.syntax.all.*
import ciris.*

case class ProgramEnvironment(pwd: String, username: String)

val config = (
  ConfigSpec.prop("user.dir"),
  ConfigSpec.prop("does.not.exist").or(ConfigSpec.env("USERNAME"))
).imapN(ProgramEnvironment.apply)(Tuple.fromProductTyped)
  .default(ProgramEnvironment("/", "default_user"))

println(ConfigSpecMarkdownInterpreter(config))
```

<details>
<summary>ConfigSpecMarkdownInterpreter.scala</summary>

```scala
import ciris.ConfigSpec
import ciris.ConfigField

object ConfigSpecMarkdownInterpreter:

  private def spacesAfter(cell: String, length: Int): String = cell + " " * (length - cell.length())
  
  def apply(spec: ConfigSpec[?]): String =
    val entries = spec.fields

    val keyHeader = "Key"
    val defaultValueHeader = "Default Value"
    
    val maxKeyLength = entries.map(_.key.description.length()).maxOption.getOrElse(0).max(keyHeader.length())
    val maxDefaultValueLength = entries.map(_.defaultValue.fold(1)(_.length())).maxOption.getOrElse(0).max(defaultValueHeader.length())

    val rows = entries
      .map:
        case ConfigField(key, defaultValue) =>
          s"| ${spacesAfter(key.description, maxKeyLength)} | ${spacesAfter(defaultValue.getOrElse("-"), maxDefaultValueLength)} |"
      .mkString("\n|")

    val header = s"| ${spacesAfter(keyHeader, maxKeyLength)} | ${spacesAfter(defaultValueHeader, maxDefaultValueLength)} |"
    val separator = s"| ${"-" * maxKeyLength} | ${"-" * maxDefaultValueLength} |"
    
    s"""|$header
        |$separator
        |$rows""".stripMargin
```

</details>

Output:

```md
| Key                            | Default Value |
| ------------------------------ | ------------- |
| system property user.dir       | /             |
| system property does.not.exist | default_user  |
| environment variable USERNAME  | default_user  |
```
| Key                            | Default Value |
| ------------------------------ | ------------- |
| system property user.dir       | /             |
| system property does.not.exist | default_user  |
| environment variable USERNAME  | default_user  |