### PR TITLE
Add alt as a more permissive alternative to or

### DIFF
--- a/modules/core/shared/src/main/scala/ciris/ConfigError.scala
+++ b/modules/core/shared/src/main/scala/ciris/ConfigError.scala
@@ -93,6 +93,29 @@ sealed abstract class ConfigError {
     }
 
   /**
+    * Returns `true` if the error is due to a non-fatal
+    * error; otherwise `false`.
+    *
+    * If the error is a combination of multiple errors,
+    * returns `true` if all errors are due to non-fatal
+    * errors; otherwise `false`.
+    *
+    * A non-fatal error is any error without an error
+    * message. Fatal errors are created by [[apply]]
+    * and [[sensitive]].
+    */
+  private[ciris] final def isNonFatal: Boolean =
+    this match {
+      case And(errors)     => errors.forall(_.isNonFatal)
+      case Apply(_)        => false
+      case Empty           => true
+      case Loaded          => true
+      case Missing(_)      => true
+      case Or(errors)      => errors.forall(_.isNonFatal)
+      case Sensitive(_, _) => false
+    }
+
+  /**
     * Returns a new [[ConfigError]] combining errors for
     * a single configuration value.
     */

--- a/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -105,67 +105,67 @@ final class ConfigValueSpec extends CatsEffectSuite with ScalaCheckEffectSuite w
   def checkLoadFail[A](actual: ConfigValue[IO, A]): IO[Unit] =
     actual.load.attempt.map(_.isLeft).assert
 
-  test("ConfigValue.alt.loaded or loaded") {
+  test("ConfigValue.alt.loaded alt loaded") {
     checkLoad(loaded.alt(loaded2), loadedValue)
   }
 
-  test("ConfigValue.alt.loaded or failed") {
+  test("ConfigValue.alt.loaded alt failed") {
     checkLoad(loaded.alt(failed), loadedValue)
   }
 
-  test("ConfigValue.alt.loaded or missing") {
+  test("ConfigValue.alt.loaded alt missing") {
     checkLoad(loaded.alt(missing), loadedValue)
   }
 
-  test("ConfigValue.alt.loaded or default") {
+  test("ConfigValue.alt.loaded alt default") {
     checkLoad(loaded.alt(default), loadedValue)
   }
 
-  test("ConfigValue.alt.failed or loaded") {
+  test("ConfigValue.alt.failed alt loaded") {
     checkError(failed.alt(loaded), failedError)
   }
 
-  test("ConfigValue.alt.failed or failed") {
+  test("ConfigValue.alt.failed alt failed") {
     checkError(failed.alt(failed2), failedError)
   }
 
-  test("ConfigValue.alt.failed or missing") {
+  test("ConfigValue.alt.failed alt missing") {
     checkError(failed.alt(missing), failedError)
   }
 
-  test("ConfigValue.alt.failed or default") {
+  test("ConfigValue.alt.failed alt default") {
     checkError(failed.alt(default), failedError)
   }
 
-  test("ConfigValue.alt.missing or loaded") {
+  test("ConfigValue.alt.missing alt loaded") {
     checkLoad(missing.alt(loaded), loadedValue)
   }
 
-  test("ConfigValue.alt.missing or failed") {
+  test("ConfigValue.alt.missing alt failed") {
     checkError(missing.alt(failed), missingError.or(failedError))
   }
 
-  test("ConfigValue.alt.missing or missing") {
+  test("ConfigValue.alt.missing alt missing") {
     checkError(missing.alt(missing2), missingError.or(missingError2))
   }
 
-  test("ConfigValue.alt.missing or default") {
+  test("ConfigValue.alt.missing alt default") {
     checkLoad(missing.alt(default), defaultValue)
   }
 
-  test("ConfigValue.alt.default or loaded") {
+  test("ConfigValue.alt.default alt loaded") {
     checkLoad(default.alt(loaded), loadedValue)
   }
 
-  test("ConfigValue.alt.default or failed") {
+  test("ConfigValue.alt.default alt failed") {
     checkError(default.alt(failed), defaultError.or(failedError))
   }
 
-  test("ConfigValue.alt.default or missing") {
+  test("ConfigValue.alt.default alt missing") {
     checkLoad(default.alt(missing), defaultValue)
   }
 
-  test("ConfigValue.alt.default or default") {
+  test("ConfigValue.alt.default alt default") {
     checkLoad(default.alt(default2), defaultValue2)
   }
 

--- a/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -562,6 +562,70 @@ final class ConfigValueSpec extends CatsEffectSuite with ScalaCheckEffectSuite w
     )
   }
 
+  test("ConfigValue.firstValid.loaded or loaded") {
+    checkLoad(loaded.findValid(loaded2), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.loaded or failed") {
+    checkLoad(loaded.findValid(failed), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.loaded or missing") {
+    checkLoad(loaded.findValid(missing), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.loaded or default") {
+    checkLoad(loaded.findValid(default), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.failed or loaded") {
+    checkError(failed.findValid(loaded), failedError)
+  }
+
+  test("ConfigValue.firstValid.failed or failed") {
+    checkError(failed.findValid(failed2), failedError)
+  }
+
+  test("ConfigValue.firstValid.failed or missing") {
+    checkError(failed.findValid(missing), failedError)
+  }
+
+  test("ConfigValue.firstValid.failed or default") {
+    checkError(failed.findValid(default), failedError)
+  }
+
+  test("ConfigValue.firstValid.missing or loaded") {
+    checkLoad(missing.findValid(loaded), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.missing or failed") {
+    checkError(missing.findValid(failed), missingError.or(failedError))
+  }
+
+  test("ConfigValue.firstValid.missing or missing") {
+    checkError(missing.findValid(missing2), missingError.or(missingError2))
+  }
+
+  test("ConfigValue.firstValid.missing or default") {
+    checkLoad(missing.findValid(default), defaultValue)
+  }
+
+  test("ConfigValue.firstValid.default or loaded") {
+    checkLoad(default.findValid(loaded), loadedValue)
+  }
+
+  test("ConfigValue.firstValid.default or failed") {
+    checkError(default.findValid(failed), defaultError.or(failedError))
+  }
+
+  test("ConfigValue.firstValid.default or missing") {
+    checkLoad(default.findValid(missing), defaultValue)
+  }
+
+  test("ConfigValue.firstValid.default or default") {
+    checkLoad(default.findValid(default2), defaultValue2)
+  }
+
   test("ConfigValue.parallel.(default, default).parTupled") {
     check(
       (default, default2).parTupled,

--- a/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
+++ b/modules/core/shared/src/test/scala/ciris/ConfigValueSpec.scala
@@ -104,6 +104,70 @@ final class ConfigValueSpec extends CatsEffectSuite with ScalaCheckEffectSuite w
   def checkLoadFail[A](actual: ConfigValue[IO, A]): IO[Unit] =
     actual.load.attempt.map(_.isLeft).assert
 
+  test("ConfigValue.alt.loaded or loaded") {
+    checkLoad(loaded.alt(loaded2), loadedValue)
+  }
+
+  test("ConfigValue.alt.loaded or failed") {
+    checkLoad(loaded.alt(failed), loadedValue)
+  }
+
+  test("ConfigValue.alt.loaded or missing") {
+    checkLoad(loaded.alt(missing), loadedValue)
+  }
+
+  test("ConfigValue.alt.loaded or default") {
+    checkLoad(loaded.alt(default), loadedValue)
+  }
+
+  test("ConfigValue.alt.failed or loaded") {
+    checkError(failed.alt(loaded), failedError)
+  }
+
+  test("ConfigValue.alt.failed or failed") {
+    checkError(failed.alt(failed2), failedError)
+  }
+
+  test("ConfigValue.alt.failed or missing") {
+    checkError(failed.alt(missing), failedError)
+  }
+
+  test("ConfigValue.alt.failed or default") {
+    checkError(failed.alt(default), failedError)
+  }
+
+  test("ConfigValue.alt.missing or loaded") {
+    checkLoad(missing.alt(loaded), loadedValue)
+  }
+
+  test("ConfigValue.alt.missing or failed") {
+    checkError(missing.alt(failed), missingError.or(failedError))
+  }
+
+  test("ConfigValue.alt.missing or missing") {
+    checkError(missing.alt(missing2), missingError.or(missingError2))
+  }
+
+  test("ConfigValue.alt.missing or default") {
+    checkLoad(missing.alt(default), defaultValue)
+  }
+
+  test("ConfigValue.alt.default or loaded") {
+    checkLoad(default.alt(loaded), loadedValue)
+  }
+
+  test("ConfigValue.alt.default or failed") {
+    checkError(default.alt(failed), defaultError.or(failedError))
+  }
+
+  test("ConfigValue.alt.default or missing") {
+    checkLoad(default.alt(missing), defaultValue)
+  }
+
+  test("ConfigValue.alt.default or default") {
+    checkLoad(default.alt(default2), defaultValue2)
+  }
+
   test("ConfigValue.as.default success") {
     check(default.as[String], default)
   }
@@ -560,70 +624,6 @@ final class ConfigValueSpec extends CatsEffectSuite with ScalaCheckEffectSuite w
       default.or(default2),
       defaultWith(defaultError.or(defaultError2), defaultValue2)
     )
-  }
-
-  test("ConfigValue.firstValid.loaded or loaded") {
-    checkLoad(loaded.findValid(loaded2), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.loaded or failed") {
-    checkLoad(loaded.findValid(failed), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.loaded or missing") {
-    checkLoad(loaded.findValid(missing), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.loaded or default") {
-    checkLoad(loaded.findValid(default), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.failed or loaded") {
-    checkError(failed.findValid(loaded), failedError)
-  }
-
-  test("ConfigValue.firstValid.failed or failed") {
-    checkError(failed.findValid(failed2), failedError)
-  }
-
-  test("ConfigValue.firstValid.failed or missing") {
-    checkError(failed.findValid(missing), failedError)
-  }
-
-  test("ConfigValue.firstValid.failed or default") {
-    checkError(failed.findValid(default), failedError)
-  }
-
-  test("ConfigValue.firstValid.missing or loaded") {
-    checkLoad(missing.findValid(loaded), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.missing or failed") {
-    checkError(missing.findValid(failed), missingError.or(failedError))
-  }
-
-  test("ConfigValue.firstValid.missing or missing") {
-    checkError(missing.findValid(missing2), missingError.or(missingError2))
-  }
-
-  test("ConfigValue.firstValid.missing or default") {
-    checkLoad(missing.findValid(default), defaultValue)
-  }
-
-  test("ConfigValue.firstValid.default or loaded") {
-    checkLoad(default.findValid(loaded), loadedValue)
-  }
-
-  test("ConfigValue.firstValid.default or failed") {
-    checkError(default.findValid(failed), defaultError.or(failedError))
-  }
-
-  test("ConfigValue.firstValid.default or missing") {
-    checkLoad(default.findValid(missing), defaultValue)
-  }
-
-  test("ConfigValue.firstValid.default or default") {
-    checkLoad(default.findValid(default2), defaultValue2)
   }
 
   test("ConfigValue.parallel.(default, default).parTupled") {


### PR DESCRIPTION
Adds `alt` as a more permissive alternative to `or` as a possible solution for #850

These helpers will be assumed for the examples:
```scala
val l  = ConfigValue.loaded(ConfigKey("loaded 0", 0))
val l1 = ConfigValue.loaded(ConfigKey("loaded 1", 1))

val mE  = ConfigError.Missing(ConfigKey("missing 0"))
val mE1 = ConfigError.Missing(ConfigKey("missing 0"))
val m  = ConfigValue.failed(mE)
val m1 = ConfigValue.failed(mE0)

val fE  = ConfigError("failed 0")
val f  = ConfigValue.failed(fE)

val d  = ConfigValue.default(2)
val d1 = ConfigValue.default(3)
```

When `a` is a singular value, the behavior of `or` and `alt` are identical:
| `lhs` | `rhs` | `lhs.or(rhs)`            | `lhs.alt(rhs)`     |
| :---- | :---- | :----------------------- | :----------------------- |
| `l`   | `*`   | Loaded: `0`              | Loaded: `0`              |
| `f`   | `*`   | Failed with `fE`         | Failed with `fE`         |
| `m`   | `l`   | Loaded: `0`              | Loaded: `0`              |
| `m`   | `m1`  | Failed with `mE.or(mE1)` | Failed with `mE.or(mE1)` |
| `m`   | `f`   | Failed with `mE.or(fE)`  | Failed with `mE.or(fE)`  |
| `m`   | `d`   | Loaded: `2`              | Loaded: `2`              |
| `d`   | `l`   | Loaded: `0`              | Loaded: `0`              |
| `d`   | `m`   | Loaded: `2`              | Loaded: `2`              |
| `d`   | `f`   | Failed with `fE`         | Failed with `fE`         |
| `d`   | `d1`  | Loaded: `2`              | Loaded: `2`              |

When `a` is a compound values, the behavior of `or` and `alt` diverges in
these specific failure cases (and only in these cases):
| `lhs`               | `rhs` | `lhs.or(rhs)`                | `lhs.alt(rhs)`      |
| :------------------ | :---- | :--------------------------- | :------------------------ |
| `(m, l).parTupled`  | `l1`  | Failed with `mE.and(Loaded)` | Loaded: `1`               |
| `(m, d).parTupled`  | `l`   | Failed with `mE`             | Loaded: `0`               |
| `(l, m).parTupled`  | `l1`  | Failed with `Loaded.and(mE)` | Loaded: `1`               |
| `(d, m).parTupled`  | `l`   | Failed with `mE`             | Loaded: `0`               |